### PR TITLE
Url prefix

### DIFF
--- a/gazettes/gazette_access.py
+++ b/gazettes/gazette_access.py
@@ -55,8 +55,13 @@ class GazetteAccess(GazetteAccessInterface):
 
     _data_gateway = None
 
-    def __init__(self, gazette_data_gateway=None):
+    def __init__(self, gazette_data_gateway=None, url_prefix: str = ""):
         self._data_gateway = gazette_data_gateway
+        self._url_prefix = url_prefix
+
+    def update_gazette_url(self, gazette):
+        if len(self._url_prefix) > 0:
+            gazette.url = f"{self._url_prefix}/{gazette.url}"
 
     def get_gazettes(self, filters: GazetteRequest = None):
         territory_id = filters.territory_id if filters is not None else None
@@ -73,6 +78,7 @@ class GazetteAccess(GazetteAccessInterface):
             page=page,
             page_size=page_size,
         ):
+            self.update_gazette_url(gazette)
             yield vars(gazette)
 
 
@@ -101,9 +107,9 @@ class Gazette:
         )
 
 
-def create_gazettes_interface(data_gateway: GazetteDataGateway):
+def create_gazettes_interface(data_gateway: GazetteDataGateway, url_prefix: str = ""):
     if not isinstance(data_gateway, GazetteDataGateway):
         raise Exception(
             "Data gateway should implement the GazetteDataGateway interface"
         )
-    return GazetteAccess(data_gateway)
+    return GazetteAccess(data_gateway, url_prefix)

--- a/main/__main__.py
+++ b/main/__main__.py
@@ -9,8 +9,12 @@ from database import create_elasticsearch_data_mapper
 host = os.environ["QUERIDO_DIARIO_ELASTICSEARCH_HOST"]
 index = os.environ["QUERIDO_DIARIO_ELASTICSEARCH_INDEX"]
 
+def get_url_prefix():
+    return os.environ.get("QUERIDO_DIARIO_URL_PREFIX", "")
+
+
 datagateway = create_elasticsearch_data_mapper(host, index)
-gazettes_interface = create_gazettes_interface(datagateway)
+gazettes_interface = create_gazettes_interface(datagateway, get_url_prefix())
 set_gazette_interface(gazettes_interface)
 
 uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,9 @@ from .gazette_access_tests import (
     GazetteTest,
     GazetteRequestTest,
     GazetteAccessInterfacesTest,
+    GazetteAccessBaseTests,
 )
+
 from .api_tests import ApiGazettesEndpointTests
 
 from .elasticsearch_tests import (


### PR DESCRIPTION
Adds a new attribute in the GazetteAccess class to allow the user set a prefix for the gazettes url. Thus, it is possible to define here the files should be downloaded.