### PR TITLE
Config package and API app root_path

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,1 +1,1 @@
-from .api import app, set_gazette_interface
+from .api import app, configure_api_app

--- a/api/api.py
+++ b/api/api.py
@@ -115,7 +115,10 @@ async def get_gazettes_by_territory_id(
     )
 
 
-def set_gazette_interface(gazettes: GazetteAccessInterface):
+def configure_api_app(gazettes: GazetteAccessInterface, api_root_path=None):
     if not isinstance(gazettes, GazetteAccessInterface):
         raise Exception("Only GazetteAccessInterface object are accepted")
+    if api_root_path is not None and type(api_root_path) != str:
+        raise Exception("Invalid api_root_path")
     app.gazettes = gazettes
+    app.root_path = api_root_path

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+from .config import load_configuration

--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,13 @@
+import os
+
+
+class Configuration:
+    def __init__(self):
+        self.host = os.environ.get("QUERIDO_DIARIO_ELASTICSEARCH_HOST", "")
+        self.index = os.environ.get("QUERIDO_DIARIO_ELASTICSEARCH_INDEX", "")
+        self.root_path = os.environ.get("QUERIDO_DIARIO_API_ROOT_PATH", "")
+        self.url_prefix = os.environ.get("QUERIDO_DIARIO_URL_PREFIX", "")
+
+
+def load_configuration():
+    return Configuration()

--- a/main/__main__.py
+++ b/main/__main__.py
@@ -2,20 +2,14 @@ import os
 
 import uvicorn
 
-from api import app, set_gazette_interface
+from api import app, configure_api_app
 from gazettes import create_gazettes_interface
 from database import create_elasticsearch_data_mapper
+from config import load_configuration
 
-host = os.environ["QUERIDO_DIARIO_ELASTICSEARCH_HOST"]
-index = os.environ["QUERIDO_DIARIO_ELASTICSEARCH_INDEX"]
-root_path = os.environ.get("QUERIDO_DIARIO_API_ROOT_PATH", "")
+configuration = load_configuration()
+datagateway = create_elasticsearch_data_mapper(configuration.host, configuration.index)
+gazettes_interface = create_gazettes_interface(datagateway, configuration.url_prefix)
+configure_api_app(gazettes_interface, configuration.root_path)
 
-def get_url_prefix():
-    return os.environ.get("QUERIDO_DIARIO_URL_PREFIX", "")
-
-
-datagateway = create_elasticsearch_data_mapper(host, index)
-gazettes_interface = create_gazettes_interface(datagateway, get_url_prefix())
-set_gazette_interface(gazettes_interface)
-
-uvicorn.run(app, host="0.0.0.0", port=8080, root_path=root_path)
+uvicorn.run(app, host="0.0.0.0", port=8080, root_path=configuration.root_path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,3 +16,5 @@ from .elasticsearch_tests import (
     ElasticSearchDataMapperPaginationTest,
     ElasticSearchDataMapperKeywordTest,
 )
+
+from .config_tests import BasicConfigurationTests

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -1,10 +1,10 @@
 from datetime import date
 from unittest.mock import MagicMock
-from unittest import TestCase
+from unittest import TestCase, expectedFailure
 
 from fastapi.testclient import TestClient
 
-from api import app, set_gazette_interface
+from api import app, configure_api_app
 from gazettes import GazetteAccessInterface, GazetteRequest
 
 
@@ -21,14 +21,14 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_api_should_fail_when_try_to_set_any_object_as_gazettes_interface(self):
         with self.assertRaises(Exception):
-            set_gazette_interface(MagicMock())
+            configure_api_app(MagicMock())
 
     def test_api_should_not_fail_when_try_to_set_any_object_as_gazettes_interface(self):
-        set_gazette_interface(MockGazetteAccessInterface())
+        configure_api_app(MockGazetteAccessInterface())
 
     def test_gazettes_endpoint_should_accept_territory_id_in_the_path(self):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get("/gazettes/4205902")
         self.assertEqual(response.status_code, 200)
@@ -42,7 +42,7 @@ class ApiGazettesEndpointTests(TestCase):
         self.assertIsNotNone(interface.get_gazettes.call_args.args[0].page_size)
 
     def test_gazettes_endpoint_should_accept_query_since_date(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get(
             "/gazettes/4205902", params={"since": date.today().strftime("%Y-%m-%d")}
@@ -50,7 +50,7 @@ class ApiGazettesEndpointTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_gazettes_endpoint_should_accept_query_until_date(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get(
             "/gazettes/4205902", params={"until": date.today().strftime("%Y-%m-%d")}
@@ -58,19 +58,19 @@ class ApiGazettesEndpointTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_gazettes_endpoint_should_fail_with_invalid_since_value(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get("/gazettes/4205902", params={"since": "foo-bar-2222"})
         self.assertEqual(response.status_code, 422)
 
     def test_gazettes_endpoint_should_fail_with_invalid_until_value(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get("/gazettes/4205902", params={"until": "foo-bar-2222"})
         self.assertEqual(response.status_code, 422)
 
     def test_gazettes_endpoint_should_fail_with_invalid_pagination_data(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get(
             "/gazettes/4205902", params={"page": "asfasdasd", "page_size": "10"}
@@ -87,7 +87,7 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_get_gazettes_without_territory_id_should_be_fine(self):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get("/gazettes/")
         self.assertEqual(response.status_code, 200)
@@ -100,7 +100,7 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_get_gazettes_should_request_gazettes_to_interface_object(self):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get("/gazettes/4205902")
         self.assertEqual(response.status_code, 200)
@@ -108,7 +108,7 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_get_gazettes_should_forward_gazettes_filters_to_interface_object(self):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get(
             "/gazettes/4205902",
@@ -142,7 +142,7 @@ class ApiGazettesEndpointTests(TestCase):
                 }
             ]
         )
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get("/gazettes/4205902")
         interface.get_gazettes.assert_called_once()
@@ -164,7 +164,7 @@ class ApiGazettesEndpointTests(TestCase):
     def test_get_gazettes_should_return_empty_list_when_no_gazettes_is_found(self):
         today = date.today()
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get("/gazettes/4205902")
         interface.get_gazettes.assert_called_once()
@@ -175,7 +175,7 @@ class ApiGazettesEndpointTests(TestCase):
         self.assertEqual(response.json(), [])
 
     def test_gazettes_endpoint_should_accept_query_keywords_date(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get(
             "/gazettes/4205902", params={"keywords": ["keyword1" "keyword2"]}
@@ -186,7 +186,7 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_get_gazettes_should_forwards_keywords_to_interface_object(self):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
 
         response = client.get(
@@ -198,13 +198,13 @@ class ApiGazettesEndpointTests(TestCase):
         )
 
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         response = client.get("/gazettes/4205902", params={"keywords": []})
         interface.get_gazettes.assert_called_once()
         self.assertIsNone(interface.get_gazettes.call_args.args[0].keywords)
 
     def test_gazettes_without_territory_endpoint__should_accept_query_since_date(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get(
             "/gazettes", params={"since": date.today().strftime("%Y-%m-%d")}
@@ -212,7 +212,7 @@ class ApiGazettesEndpointTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_gazettes_without_territory_endpoint__should_accept_query_until_date(self):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get(
             "/gazettes", params={"until": date.today().strftime("%Y-%m-%d")}
@@ -222,7 +222,7 @@ class ApiGazettesEndpointTests(TestCase):
     def test_gazettes_without_territory_endpoint__should_fail_with_invalid_since_value(
         self,
     ):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get("/gazettes", params={"since": "foo-bar-2222"})
         self.assertEqual(response.status_code, 422)
@@ -230,7 +230,7 @@ class ApiGazettesEndpointTests(TestCase):
     def test_gazettes_without_territory_endpoint__should_fail_with_invalid_until_value(
         self,
     ):
-        set_gazette_interface(self.create_mock_gazette_interface())
+        configure_api_app(self.create_mock_gazette_interface())
         client = TestClient(app)
         response = client.get("/gazettes", params={"until": "foo-bar-2222"})
         self.assertEqual(response.status_code, 422)
@@ -239,7 +239,7 @@ class ApiGazettesEndpointTests(TestCase):
         self,
     ):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get(
             "/gazettes",
@@ -262,9 +262,17 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_api_should_decrease_one_from_page_number_for_internal_use(self):
         interface = self.create_mock_gazette_interface()
-        set_gazette_interface(interface)
+        configure_api_app(interface)
         client = TestClient(app)
         response = client.get("/gazettes", params={"page": 1,},)
         self.assertEqual(response.status_code, 200)
         interface.get_gazettes.assert_called_once()
         self.assertEqual(interface.get_gazettes.call_args.args[0].page, 0)
+
+    @expectedFailure
+    def test_configure_api_should_failed_with_invalid_root_path(self):
+        configure_api_app(MockGazetteAccessInterface(), api_root_path=1)
+
+    def test_configure_api_root_path(self):
+        configure_api_app(MockGazetteAccessInterface(), api_root_path="/api/v1")
+        self.assertEqual("/api/v1", app.root_path)

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -1,0 +1,82 @@
+from unittest import TestCase
+
+from unittest.mock import patch
+
+from config import load_configuration
+
+
+class BasicConfigurationTests(TestCase):
+    def check_configuration_values(self, configuration, expected_values):
+        self.assertEqual(
+            configuration.host,
+            expected_values["QUERIDO_DIARIO_ELASTICSEARCH_HOST"],
+            msg="Invalid elasticsearch host",
+        )
+        self.assertEqual(
+            configuration.index,
+            expected_values["QUERIDO_DIARIO_ELASTICSEARCH_INDEX"],
+            msg="Invalid elasticsearch index",
+        )
+        self.assertEqual(
+            configuration.root_path,
+            expected_values["QUERIDO_DIARIO_API_ROOT_PATH"],
+            msg="Invalid API root path",
+        )
+        self.assertEqual(
+            configuration.url_prefix,
+            expected_values["QUERIDO_DIARIO_URL_PREFIX"],
+            msg="Invalid URL prefix",
+        )
+
+    @patch.dict(
+        "os.environ", {}, True,
+    )
+    def test_load_configuration_with_no_envvars(self):
+        expected_config_dict = {
+            "QUERIDO_DIARIO_ELASTICSEARCH_HOST": "",
+            "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "",
+            "QUERIDO_DIARIO_API_ROOT_PATH": "",
+            "QUERIDO_DIARIO_URL_PREFIX": "",
+        }
+        configuration = load_configuration()
+        self.check_configuration_values(configuration, expected_config_dict)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "QUERIDO_DIARIO_ELASTICSEARCH_HOST": "",
+            "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "",
+            "QUERIDO_DIARIO_API_ROOT_PATH": "",
+            "QUERIDO_DIARIO_URL_PREFIX": "",
+        },
+        True,
+    )
+    def test_load_configuration_with_empty_envvars(self):
+        expected_config_dict = {
+            "QUERIDO_DIARIO_ELASTICSEARCH_HOST": "",
+            "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "",
+            "QUERIDO_DIARIO_API_ROOT_PATH": "",
+            "QUERIDO_DIARIO_URL_PREFIX": "",
+        }
+        configuration = load_configuration()
+        self.check_configuration_values(configuration, expected_config_dict)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "QUERIDO_DIARIO_ELASTICSEARCH_HOST": "000.0.0.0",
+            "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "myindex",
+            "QUERIDO_DIARIO_API_ROOT_PATH": "api/",
+            "QUERIDO_DIARIO_URL_PREFIX": "https://test.com",
+        },
+        True,
+    )
+    def test_load_configuration_with_envvars_defined(self):
+        expected_config_dict = {
+            "QUERIDO_DIARIO_ELASTICSEARCH_HOST": "000.0.0.0",
+            "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "myindex",
+            "QUERIDO_DIARIO_API_ROOT_PATH": "api/",
+            "QUERIDO_DIARIO_URL_PREFIX": "https://test.com",
+        }
+        configuration = load_configuration()
+        self.check_configuration_values(configuration, expected_config_dict)


### PR DESCRIPTION
Adds the config package used to load the configuration and updates the API app to allow define the root_path. root_path is necessary to run behind a proxy