### PR TITLE
Remove url prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ IMAGE_TAG ?= latest
 # Variables used to connect the app to the ElasticSearch
 QUERIDO_DIARIO_ELASTICSEARCH_HOST ?= localhost
 QUERIDO_DIARIO_ELASTICSEARCH_INDEX ?= gazettes
-QUERIDO_DIARIO_URL_PREFIX ?= http://test.com
 ELASTICSEARCH_PORT1 ?= 9200
 ELASTICSEARCH_PORT2 ?= 9300
 # Containers data
@@ -20,7 +19,6 @@ run-command=(podman run --rm -ti --volume $(PWD):/mnt/code:rw \
 	--pod $(POD_NAME) \
 	--env QUERIDO_DIARIO_ELASTICSEARCH_INDEX=$(QUERIDO_DIARIO_ELASTICSEARCH_INDEX) \
 	--env QUERIDO_DIARIO_ELASTICSEARCH_HOST=$(QUERIDO_DIARIO_ELASTICSEARCH_HOST) \
-	--env QUERIDO_DIARIO_URL_PREFIX=$(QUERIDO_DIARIO_URL_PREFIX) \
 	--env PYTHONPATH=/mnt/code \
 	--user=$(UID):$(UID) $(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) $1)
 

--- a/database/elasticsearch.py
+++ b/database/elasticsearch.py
@@ -99,7 +99,7 @@ class ElasticSearchDataMapper(GazetteDataGateway):
             yield Gazette(
                 gazette["_source"]["territory_id"],
                 datetime.strptime(gazette["_source"]["date"], "%Y-%m-%d").date(),
-                gazette["_source"]["file_path"],
+                gazette["_source"]["url"],
             )
 
 

--- a/gazettes/gazette_access.py
+++ b/gazettes/gazette_access.py
@@ -55,13 +55,8 @@ class GazetteAccess(GazetteAccessInterface):
 
     _data_gateway = None
 
-    def __init__(self, gazette_data_gateway=None, url_prefix: str = ""):
+    def __init__(self, gazette_data_gateway=None):
         self._data_gateway = gazette_data_gateway
-        self._url_prefix = url_prefix
-
-    def update_gazette_url(self, gazette):
-        if len(self._url_prefix) > 0:
-            gazette.url = f"{self._url_prefix}/{gazette.url}"
 
     def get_gazettes(self, filters: GazetteRequest = None):
         territory_id = filters.territory_id if filters is not None else None
@@ -78,7 +73,6 @@ class GazetteAccess(GazetteAccessInterface):
             page=page,
             page_size=page_size,
         ):
-            self.update_gazette_url(gazette)
             yield vars(gazette)
 
 
@@ -107,9 +101,9 @@ class Gazette:
         )
 
 
-def create_gazettes_interface(data_gateway: GazetteDataGateway, url_prefix: str = ""):
+def create_gazettes_interface(data_gateway: GazetteDataGateway):
     if not isinstance(data_gateway, GazetteDataGateway):
         raise Exception(
             "Data gateway should implement the GazetteDataGateway interface"
         )
-    return GazetteAccess(data_gateway, url_prefix)
+    return GazetteAccess(data_gateway)

--- a/main/__main__.py
+++ b/main/__main__.py
@@ -12,4 +12,9 @@ datagateway = create_elasticsearch_data_mapper(configuration.host, configuration
 gazettes_interface = create_gazettes_interface(datagateway, configuration.url_prefix)
 configure_api_app(gazettes_interface, configuration.root_path)
 
-uvicorn.run(app, host="0.0.0.0", port=8080, root_path=configuration.root_path)
+
+datagateway = create_elasticsearch_data_mapper(host, index)
+gazettes_interface = create_gazettes_interface(datagateway)
+set_gazette_interface(gazettes_interface)
+
+uvicorn.run(app, host="0.0.0.0", port=8080, root_path=root_path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,6 @@ from .gazette_access_tests import (
     GazetteTest,
     GazetteRequestTest,
     GazetteAccessInterfacesTest,
-    GazetteAccessBaseTests,
 )
 
 from .api_tests import ApiGazettesEndpointTests

--- a/tests/elasticsearch_tests.py
+++ b/tests/elasticsearch_tests.py
@@ -11,6 +11,8 @@ from database import ElasticSearchDataMapper, create_elasticsearch_data_mapper
 from gazettes import GazetteDataGateway, Gazette
 
 
+FILE_ENDPOINT = "http://test.com"
+
 def is_elasticsearch_status_green(es):
     status = es.cluster.stats()
     if status["status"] == "green":
@@ -94,7 +96,7 @@ class ElasticSearchBaseTestCase(TestCase):
     def get_latest_gazettes_files(self, gazettes_count):
         self._data.sort(reverse=True, key=lambda x: x["date"])
         return [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data[:gazettes_count]
         ]
 
@@ -149,6 +151,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e5",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -164,6 +167,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e52",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -179,6 +183,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e53",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -194,6 +199,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e54",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -209,6 +215,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e55",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -224,6 +231,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e56",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -239,6 +247,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e57",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -254,6 +263,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e58",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -269,6 +279,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e59",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -284,6 +295,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e510",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -299,6 +311,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e511",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -314,6 +327,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e512",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -347,7 +361,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
         two_weeks_ago = date.today() - timedelta(days=14)
         gazettes = list(self._mapper.get_gazettes(since=two_weeks_ago))
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"]) for d in self._data
+            Gazette(d["territory_id"], d["date"], d["url"]) for d in self._data
         ]
         self.assertGreater(len(gazettes), 0)
         self.assertGreater(gazettes[0].date, gazettes[-1].date)
@@ -355,7 +369,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
     def test_search_gazettes_since_date(self):
         gazettes = self._mapper.get_gazettes(since=date.today())
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if d["date"] >= date.today()
         ]
@@ -365,7 +379,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
         yesterday = date.today() - timedelta(days=1)
         gazettes = self._mapper.get_gazettes(until=yesterday)
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if d["date"] <= yesterday
         ]
@@ -374,7 +388,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
     def test_search_gazettes_by_territory_id(self):
         gazettes = list(self._mapper.get_gazettes(territory_id=self.TERRITORY_ID1))
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if d["territory_id"] == self.TERRITORY_ID1
         ]
@@ -384,7 +398,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
         week_ago = date.today() - timedelta(days=7)
         day = timedelta(days=1)
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if d["territory_id"] == self.TERRITORY_ID4
             and d["date"] >= (week_ago - day)
@@ -399,7 +413,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
     def test_get_gazettes_by_keywords(self):
         gazettes = self._mapper.get_gazettes(keywords=["000.000.000-00"])
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if "000.000.000-00" in d["source_text"]
         ]
@@ -407,7 +421,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
 
         gazettes = self._mapper.get_gazettes(keywords=["anotherkeyword"])
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if "anotherkeyword" in d["source_text"]
         ]
@@ -415,7 +429,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
 
         gazettes = self._mapper.get_gazettes(keywords=["keyword1"])
         expected_gazettes = [
-            Gazette(d["territory_id"], d["date"], d["file_path"])
+            Gazette(d["territory_id"], d["date"], d["url"])
             for d in self._data
             if "keyword1" in d["source_text"]
         ]
@@ -454,6 +468,7 @@ class ElasticSearchDataMapperPaginationTest(ElasticSearchBaseTestCase):
             "power": "executive",
             "file_checksum": document_uuid,
             "file_path": f"3304557/2019-02-26/{document_uuid}",
+            "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/{document_uuid}",
             "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
             "scraped_at": "2020-10-30T07:04:29.796347",
             "created_at": "2020-10-30T07:05:33.094289",
@@ -595,6 +610,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e5",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -611,6 +627,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e51",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -627,6 +644,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e52",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",
@@ -643,6 +661,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchBaseTestCase):
                 "power": "executive",
                 "file_checksum": "2566f0e0ff98d899ee0633da64bc65e53",
                 "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
+                "url": f"{FILE_ENDPOINT}/3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
                 "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
                 "scraped_at": "2020-10-30T07:04:29.796347",
                 "created_at": "2020-10-30T07:05:33.094289",

--- a/tests/gazette_access_tests.py
+++ b/tests/gazette_access_tests.py
@@ -35,11 +35,6 @@ class GazetteAccessInterfacesTest(TestCase):
         interface = create_gazettes_interface(DummyDataGateway())
         self.assertIsInstance(interface, GazetteAccessInterface)
 
-    def test_create_gazettes_interface_with_url_prefix(self):
-        interface = create_gazettes_interface(DummyDataGateway(), "http://test.com")
-        self.assertIsInstance(interface, GazetteAccessInterface)
-        self.assertEqual(interface._url_prefix, "http://test.com")
-
     @unittest.expectedFailure
     def test_create_gazettes_interface_with_invalid_data_gateway_should_fail(self):
         interace = create_gazettes_interface(InvalidDataGateway())
@@ -217,25 +212,3 @@ class GazetteTest(TestCase):
         self.assertEqual(today, gazette.date)
         self.assertIsInstance(gazette.url, str, msg="URL should be a string")
         self.assertEqual(url, gazette.url)
-
-
-class GazetteAccessBaseTests(TestCase):
-    @patch("gazettes.GazetteDataGateway")
-    def test_adding_url_prefix_in_gazettes(self, data_gateway_mock):
-        returned_gazette = Gazette("9999", "2020-01-01", "fake/path/to/file")
-        data_gateway_mock.get_gazettes = MagicMock(return_value=[returned_gazette])
-        url_prefix = "https://test.com.br"
-
-        gazettes_access = GazetteAccess(data_gateway_mock, url_prefix)
-        values = next(gazettes_access.get_gazettes())
-
-        self.assertEqual(
-            values,
-            {
-                "territory_id": "9999",
-                "date": "2020-01-01",
-                "url": f"{url_prefix}/fake/path/to/file",
-            },
-        )
-
-        data_gateway_mock.get_gazettes.assert_called_once()


### PR DESCRIPTION
Removes the code used to build the URL where the gazette file is stored.
Now, the index should contain the url field with the information.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>