### PR TITLE
Return highlight text

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -97,7 +97,7 @@ async def get_gazettes(
     ),
     fragment_size: Optional[int] = Query(
         150,
-        title=" Number of fragments (characters) of highlight to return.",
+        title="Number of fragments (characters) of highlight to return.",
         description="Define the fragments (characters)  of highlight of the item should be returned",
     ),
     pre_tags: List[str] = Query(
@@ -149,18 +149,18 @@ async def get_gazettes_by_territory_id(
     ),
     fragment_size: Optional[int] = Query(
         150,
-        title="Number of fragments of hightlight to return",
-        description="Define the fragments of hightlight of item should be returned",
+        title="Number of fragments (characters) of highlight to return.",
+        description="Define the fragments (characters)  of highlight of the item should be returned",
     ),
     pre_tags: List[str] = Query(
         [""],
-        title="Pre tags of fragments of hightlight",
-        description="Pre tags of fragments of hightlight",
+        title="Pre tags of fragments of highlight",
+        description="Pre tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear before the text which matches the query",
     ),
     post_tags: List[str] = Query(
         [""],
-        title="Post tags of fragments of hightlight",
-        description="Post tags of fragments of hightlight",
+        title="Post tags of fragments of highlight.",
+        description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
 ):
     return trigger_gazettes_search(territory_id, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags)

--- a/api/api.py
+++ b/api/api.py
@@ -19,6 +19,7 @@ class GazetteItem(BaseModel):
     url: str
     territory_name: str
     state_code: str
+    highlight_text: str
     edition: Optional[str]
     is_extra_edition: Optional[bool]
 
@@ -35,6 +36,9 @@ def trigger_gazettes_search(
     keywords: List[str] = None,
     offset: int = 0,
     size: int = 10,
+    fragment_size: int = 150,
+    pre_tags: List[str] = [""],
+    post_tags: List[str] = [""],
 ):
     gazettes_count, gazettes = app.gazettes.get_gazettes(
         GazetteRequest(
@@ -44,6 +48,9 @@ def trigger_gazettes_search(
             keywords=keywords,
             offset=offset,
             size=size,
+            fragment_size=fragment_size,
+            pre_tags=pre_tags,
+            post_tags=post_tags,
         )
     )
     response = {
@@ -88,8 +95,23 @@ async def get_gazettes(
         title="Number of item to return",
         description="Define the number of item should be returned",
     ),
+    fragment_size: Optional[int] = Query(
+        150,
+        title="Number of fragments of hightlight to return",
+        description="Define the fragments of hightlight of item should be returned",
+    ),
+    pre_tags: List[str] = Query(
+        [""],
+        title="Pre tags of fragments of hightlight",
+        description="Pre tags of fragments of hightlight",
+    ),
+    post_tags: List[str] = Query(
+        [""],
+        title="Post tags of fragments of hightlight",
+        description="Post tags of fragments of hightlight",
+    ),
 ):
-    return trigger_gazettes_search(None, since, until, keywords, offset, size)
+    return trigger_gazettes_search(None, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags)
 
 
 @app.get(
@@ -125,8 +147,23 @@ async def get_gazettes_by_territory_id(
         title="Number of item to return",
         description="Define the number of item should be returned",
     ),
+    fragment_size: Optional[int] = Query(
+        150,
+        title="Number of fragments of hightlight to return",
+        description="Define the fragments of hightlight of item should be returned",
+    ),
+    pre_tags: List[str] = Query(
+        [""],
+        title="Pre tags of fragments of hightlight",
+        description="Pre tags of fragments of hightlight",
+    ),
+    post_tags: List[str] = Query(
+        [""],
+        title="Post tags of fragments of hightlight",
+        description="Post tags of fragments of hightlight",
+    ),
 ):
-    return trigger_gazettes_search(territory_id, since, until, keywords, offset, size)
+    return trigger_gazettes_search(territory_id, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags)
 
 
 def configure_api_app(gazettes: GazetteAccessInterface, api_root_path=None):

--- a/api/api.py
+++ b/api/api.py
@@ -97,18 +97,18 @@ async def get_gazettes(
     ),
     fragment_size: Optional[int] = Query(
         150,
-        title="Number of fragments of hightlight to return",
-        description="Define the fragments of hightlight of item should be returned",
+        title=" Number of fragments (characters) of highlight to return.",
+        description="Define the fragments (characters)  of highlight of the item should be returned",
     ),
     pre_tags: List[str] = Query(
         [""],
-        title="Pre tags of fragments of hightlight",
-        description="Pre tags of fragments of hightlight",
+        title="Pre tags of fragments of highlight",
+        description="Pre tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear before the text which matches the query",
     ),
     post_tags: List[str] = Query(
         [""],
-        title="Post tags of fragments of hightlight",
-        description="Post tags of fragments of hightlight",
+        title="Post tags of fragments of highlight.",
+        description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
 ):
     return trigger_gazettes_search(None, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags)

--- a/api/api.py
+++ b/api/api.py
@@ -19,7 +19,7 @@ class GazetteItem(BaseModel):
     url: str
     territory_name: str
     state_code: str
-    highlight_text: str
+    highlight_texts: List[str]
     edition: Optional[str]
     is_extra_edition: Optional[bool]
 
@@ -37,6 +37,7 @@ def trigger_gazettes_search(
     offset: int = 0,
     size: int = 10,
     fragment_size: int = 150,
+    number_of_fragments: int = 1,
     pre_tags: List[str] = [""],
     post_tags: List[str] = [""],
 ):
@@ -49,6 +50,7 @@ def trigger_gazettes_search(
             offset=offset,
             size=size,
             fragment_size=fragment_size,
+            number_of_fragments=number_of_fragments,
             pre_tags=pre_tags,
             post_tags=post_tags,
         )
@@ -97,8 +99,13 @@ async def get_gazettes(
     ),
     fragment_size: Optional[int] = Query(
         150,
-        title="Number of fragments (characters) of highlight to return.",
-        description="Define the fragments (characters)  of highlight of the item should be returned",
+        title="Size of fragments (characters) of highlight to return.",
+        description="Define the fragments (characters) of highlight of the item should be returned",
+    ),
+    number_of_fragments: Optional[int] = Query(
+        1,
+        title="Number of fragments (blocks) of highlight to return.",
+        description="Define the number of fragments (blocks) of highlight should be returned",
     ),
     pre_tags: List[str] = Query(
         [""],
@@ -111,7 +118,7 @@ async def get_gazettes(
         description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
 ):
-    return trigger_gazettes_search(None, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags)
+    return trigger_gazettes_search(None, since, until, keywords, offset, size, fragment_size, number_of_fragments, pre_tags, post_tags)
 
 
 @app.get(
@@ -149,8 +156,13 @@ async def get_gazettes_by_territory_id(
     ),
     fragment_size: Optional[int] = Query(
         150,
-        title="Number of fragments (characters) of highlight to return.",
+        title="Size of fragments (characters) of highlight to return.",
         description="Define the fragments (characters)  of highlight of the item should be returned",
+    ),
+    number_of_fragments: Optional[int] = Query(
+        1,
+        title="Number of fragments (blocks) of highlight to return.",
+        description="Define the number of fragments (blocks) of highlight should be returned",
     ),
     pre_tags: List[str] = Query(
         [""],
@@ -163,7 +175,7 @@ async def get_gazettes_by_territory_id(
         description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
 ):
-    return trigger_gazettes_search(territory_id, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags)
+    return trigger_gazettes_search(territory_id, since, until, keywords, offset, size, fragment_size, number_of_fragments, pre_tags, post_tags)
 
 
 def configure_api_app(gazettes: GazetteAccessInterface, api_root_path=None):

--- a/database/elasticsearch.py
+++ b/database/elasticsearch.py
@@ -111,7 +111,7 @@ class ElasticSearchDataMapper(GazetteDataGateway):
             gazette["_source"]["file_checksum"],
             gazette["_source"]["territory_name"],
             gazette["_source"]["state_code"],
-            gazette["highlight"].get("source_text", []),
+            gazette["highlight"].get("source_text", []) if "highlight" in gazette else [],
             gazette["_source"].get("edition_number", None),
             gazette["_source"].get("is_extra_edition", None),
         )

--- a/database/elasticsearch.py
+++ b/database/elasticsearch.py
@@ -136,7 +136,6 @@ class ElasticSearchDataMapper(GazetteDataGateway):
         post_tags: List[str] = [""],
     ):
         query = self.build_query(territory_id, since, until, keywords, offset, size, fragment_size, number_of_fragments, pre_tags, post_tags,)
-        print(f"query->{json.dumps(query)}")
         gazettes = self._es.search(body=query, index=self._index)
 
         return (

--- a/database/elasticsearch.py
+++ b/database/elasticsearch.py
@@ -56,12 +56,12 @@ class ElasticSearchDataMapper(GazetteDataGateway):
         query["from"] = offset
         query["size"] = size
 
-    def add_highlight(self, query, fragment_size, pre_tags, post_tags):
+    def add_highlight(self, query, fragment_size, number_of_fragments, pre_tags, post_tags):
         query["highlight"] = {
             "fields": {
                 "source_text": {
                     "fragment_size": fragment_size,
-                    "number_of_fragments": 1,
+                    "number_of_fragments": number_of_fragments,
                     "type": "unified",
                     "pre_tags":pre_tags,
                     "post_tags":post_tags
@@ -78,6 +78,7 @@ class ElasticSearchDataMapper(GazetteDataGateway):
         offset: int = 0,
         size: int = 10,
         fragment_size: int = 150,
+        number_of_fragments: int = 1,
         pre_tags: List[str] = [""],
         post_tags: List[str] = [""],
     ):
@@ -98,12 +99,11 @@ class ElasticSearchDataMapper(GazetteDataGateway):
         query = {"query": {"bool": query}}
         self.add_pagination_fields(query, offset, size)
         self.build_sort_query(query)
-        self.add_highlight(query, fragment_size, pre_tags, post_tags)
+        self.add_highlight(query, fragment_size, number_of_fragments, pre_tags, post_tags)
 
         return query
 
     def _assemble_gazette_object(self, gazette):
-        highlight_texts = gazette["highlight"]["source_text"]
         return Gazette(
             gazette["_source"]["territory_id"],
             datetime.strptime(gazette["_source"]["date"], "%Y-%m-%d").date(),
@@ -111,7 +111,7 @@ class ElasticSearchDataMapper(GazetteDataGateway):
             gazette["_source"]["file_checksum"],
             gazette["_source"]["territory_name"],
             gazette["_source"]["state_code"],
-            highlight_texts[0] if highlight_texts else "",
+            gazette["highlight"].get("source_text", []),
             gazette["_source"].get("edition_number", None),
             gazette["_source"].get("is_extra_edition", None),
         )
@@ -131,10 +131,12 @@ class ElasticSearchDataMapper(GazetteDataGateway):
         offset=0,
         size=10,
         fragment_size: int = 150,
+        number_of_fragments: int = 1,
         pre_tags: List[str] = [""],
         post_tags: List[str] = [""],
     ):
-        query = self.build_query(territory_id, since, until, keywords, offset, size, fragment_size, pre_tags, post_tags,)
+        query = self.build_query(territory_id, since, until, keywords, offset, size, fragment_size, number_of_fragments, pre_tags, post_tags,)
+        print(f"query->{json.dumps(query)}")
         gazettes = self._es.search(body=query, index=self._index)
 
         return (

--- a/gazettes/gazette_access.py
+++ b/gazettes/gazette_access.py
@@ -1,4 +1,5 @@
 import abc
+from typing import List
 
 
 class GazetteRequest:
@@ -16,6 +17,9 @@ class GazetteRequest:
         keywords=None,
         offset: int = 0,
         size: int = 10,
+        fragment_size: int = 150,
+        pre_tags: List[str] = [""],
+        post_tags: List[str] = [""],
     ):
         self.territory_id = territory_id
         self.since = since
@@ -23,6 +27,9 @@ class GazetteRequest:
         self.keywords = keywords
         self.offset = offset
         self.size = size
+        self.fragment_size = fragment_size
+        self.pre_tags = pre_tags
+        self.post_tags = post_tags
 
 
 class GazetteDataGateway(abc.ABC):
@@ -32,7 +39,15 @@ class GazetteDataGateway(abc.ABC):
 
     @abc.abstractmethod
     def get_gazettes(
-        self, territory_id=None, since=None, until=None, page: int = 0, size: int = 10
+        self,
+        territory_id=None,
+        since=None,
+        until=None,
+        page: int = 0,
+        size: int = 10,
+        fragment_size: int = 150,
+        pre_tags: List[str] = [""],
+        post_tags: List[str] = [""],
     ):
         """
         Method to get the gazette from storage
@@ -65,6 +80,9 @@ class GazetteAccess(GazetteAccessInterface):
         keywords = filters.keywords if filters is not None else []
         offset = filters.offset if filters is not None else 0
         size = filters.size if filters is not None else 10
+        fragment_size = filters.fragment_size if filters is not None else 150
+        pre_tags = filters.pre_tags if filters is not None else [""]
+        post_tags = filters.post_tags if filters is not None else [""]
         total_number_gazettes, gazettes = self._data_gateway.get_gazettes(
             territory_id=territory_id,
             since=since,
@@ -72,6 +90,9 @@ class GazetteAccess(GazetteAccessInterface):
             keywords=keywords,
             offset=offset,
             size=size,
+            fragment_size=fragment_size,
+            pre_tags=pre_tags,
+            post_tags=post_tags,
         )
         return (total_number_gazettes, [vars(gazette) for gazette in gazettes])
 
@@ -89,6 +110,7 @@ class Gazette:
         checksum,
         territory_name,
         state_code,
+        highlight_text,
         edition=None,
         is_extra_edition=None,
     ):
@@ -97,6 +119,7 @@ class Gazette:
         self.url = url
         self.territory_name = territory_name
         self.state_code = state_code
+        self.highlight_text = highlight_text
         self.edition = edition
         self.is_extra_edition = is_extra_edition
         self.checksum = checksum
@@ -109,6 +132,7 @@ class Gazette:
                 self.url,
                 self.territory_name,
                 self.state_code,
+                self.highlight_text,
                 self.edition,
                 self.is_extra_edition,
                 self.checksum,
@@ -123,12 +147,13 @@ class Gazette:
             and self.url == other.url
             and self.territory_name == other.territory_name
             and self.state_code == other.state_code
+            and self.highlight_text == other.highlight_text
             and self.edition == other.edition
             and self.is_extra_edition == other.is_extra_edition
         )
 
     def __repr__(self):
-        return f"Gazette({self.checksum}, {self.territory_id}, {self.date}, {self.url}, {self.territory_name}, {self.state_code}, {self.edition}, {self.is_extra_edition})"
+        return f"Gazette({self.checksum}, {self.territory_id}, {self.date}, {self.url}, {self.territory_name}, {self.state_code}, {self.highlight_text}, {self.edition}, {self.is_extra_edition})"
 
 
 def create_gazettes_interface(data_gateway: GazetteDataGateway):

--- a/gazettes/gazette_access.py
+++ b/gazettes/gazette_access.py
@@ -1,7 +1,6 @@
 import abc
 from typing import List
 
-
 class GazetteRequest:
     """
     Object containing the data to filter gazettes
@@ -18,6 +17,7 @@ class GazetteRequest:
         offset: int = 0,
         size: int = 10,
         fragment_size: int = 150,
+        number_of_fragments: int = 1,
         pre_tags: List[str] = [""],
         post_tags: List[str] = [""],
     ):
@@ -28,6 +28,7 @@ class GazetteRequest:
         self.offset = offset
         self.size = size
         self.fragment_size = fragment_size
+        self.number_of_fragments = number_of_fragments
         self.pre_tags = pre_tags
         self.post_tags = post_tags
 
@@ -46,6 +47,7 @@ class GazetteDataGateway(abc.ABC):
         page: int = 0,
         size: int = 10,
         fragment_size: int = 150,
+        number_of_fragments: int = 1,
         pre_tags: List[str] = [""],
         post_tags: List[str] = [""],
     ):
@@ -81,6 +83,7 @@ class GazetteAccess(GazetteAccessInterface):
         offset = filters.offset if filters is not None else 0
         size = filters.size if filters is not None else 10
         fragment_size = filters.fragment_size if filters is not None else 150
+        number_of_fragments = filters.number_of_fragments if filters is not None else 1
         pre_tags = filters.pre_tags if filters is not None else [""]
         post_tags = filters.post_tags if filters is not None else [""]
         total_number_gazettes, gazettes = self._data_gateway.get_gazettes(
@@ -91,6 +94,7 @@ class GazetteAccess(GazetteAccessInterface):
             offset=offset,
             size=size,
             fragment_size=fragment_size,
+            number_of_fragments=number_of_fragments,
             pre_tags=pre_tags,
             post_tags=post_tags,
         )
@@ -110,7 +114,7 @@ class Gazette:
         checksum,
         territory_name,
         state_code,
-        highlight_text,
+        highlight_texts,
         edition=None,
         is_extra_edition=None,
     ):
@@ -119,7 +123,7 @@ class Gazette:
         self.url = url
         self.territory_name = territory_name
         self.state_code = state_code
-        self.highlight_text = highlight_text
+        self.highlight_texts = highlight_texts
         self.edition = edition
         self.is_extra_edition = is_extra_edition
         self.checksum = checksum
@@ -132,7 +136,7 @@ class Gazette:
                 self.url,
                 self.territory_name,
                 self.state_code,
-                self.highlight_text,
+                str(self.highlight_texts),
                 self.edition,
                 self.is_extra_edition,
                 self.checksum,
@@ -147,13 +151,13 @@ class Gazette:
             and self.url == other.url
             and self.territory_name == other.territory_name
             and self.state_code == other.state_code
-            and self.highlight_text == other.highlight_text
+            and str(self.highlight_texts) == str(other.highlight_texts)
             and self.edition == other.edition
             and self.is_extra_edition == other.is_extra_edition
         )
 
     def __repr__(self):
-        return f"Gazette({self.checksum}, {self.territory_id}, {self.date}, {self.url}, {self.territory_name}, {self.state_code}, {self.highlight_text}, {self.edition}, {self.is_extra_edition})"
+        return f"Gazette({self.checksum}, {self.territory_id}, {self.date}, {self.url}, {self.territory_name}, {self.state_code}, {self.highlight_texts}, {self.edition}, {self.is_extra_edition})"
 
 
 def create_gazettes_interface(data_gateway: GazetteDataGateway):

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -145,7 +145,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     }
                 ],
             )
@@ -171,7 +171,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     }
                 ],
             },
@@ -310,7 +310,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                     {
                         "territory_id": "4205902",
@@ -318,7 +318,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                 ],
             )
@@ -344,7 +344,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                     {
                         "territory_id": "4205902",
@@ -352,7 +352,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                 ],
             },
@@ -373,7 +373,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                     {
                         "territory_id": "4205902",
@@ -383,7 +383,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": None,
                         "edition": None,
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                 ],
             )
@@ -409,7 +409,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                     {
                         "territory_id": "4205902",
@@ -417,7 +417,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
-                        "highlight_text": "test",
+                        "highlight_texts": ["test"],
                     },
                 ],
             },

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -145,6 +145,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
+                        "highlight_text": "test",
                     }
                 ],
             )
@@ -170,6 +171,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
+                        "highlight_text": "test",
                     }
                 ],
             },
@@ -308,6 +310,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
+                        "highlight_text": "test",
                     },
                     {
                         "territory_id": "4205902",
@@ -315,6 +318,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "highlight_text": "test",
                     },
                 ],
             )
@@ -340,6 +344,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
+                        "highlight_text": "test",
                     },
                     {
                         "territory_id": "4205902",
@@ -347,6 +352,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "highlight_text": "test",
                     },
                 ],
             },
@@ -367,6 +373,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
+                        "highlight_text": "test",
                     },
                     {
                         "territory_id": "4205902",
@@ -376,6 +383,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": None,
                         "edition": None,
+                        "highlight_text": "test",
                     },
                 ],
             )
@@ -401,6 +409,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "state_code": "My state",
                         "is_extra_edition": False,
                         "edition": "12.3442",
+                        "highlight_text": "test",
                     },
                     {
                         "territory_id": "4205902",
@@ -408,6 +417,7 @@ class ApiGazettesEndpointTests(TestCase):
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "highlight_text": "test",
                     },
                 ],
             },

--- a/tests/elasticsearch_tests.py
+++ b/tests/elasticsearch_tests.py
@@ -125,9 +125,7 @@ class ElasticSearchBaseTestCase(TestCase):
                 "_score": None,
                 "_source": hit,
                 "highlight": {
-                    "source_text": [
-                        "highlight"
-                    ]
+                    "source_text": []
                 },
             }
             for hit in self._data
@@ -196,7 +194,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content",
@@ -215,7 +213,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content",
@@ -234,7 +232,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content. anotherkeyword",
@@ -253,7 +251,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content. keyword1",
@@ -272,7 +270,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette with some keywork which is: 000.000.000-00",
@@ -291,7 +289,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content from ID 6",
@@ -310,7 +308,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content from ID 7",
@@ -329,7 +327,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content from ID 8",
@@ -348,7 +346,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content from ID 9",
@@ -367,7 +365,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content from ID 10",
@@ -386,7 +384,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content from ID 11",
@@ -405,7 +403,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
         ]
 
@@ -719,7 +717,7 @@ class ElasticSearchDataMapperPaginationTest(ElasticSearchIntegrationBaseTestCase
             "territory_id": self.TERRITORY_ID,
             "territory_name": "Rio de Janeiro",
             "state_code": "RJ",
-            "highlight_texts": ["highlight"],
+            "highlight_texts": [],
         }
         self._data.append(gazette)
 
@@ -875,7 +873,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content. prefeitura foobar xpto piraporinha",
@@ -893,7 +891,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content. prefeitura, piraporinha and cafundo",
@@ -911,7 +909,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
             {
                 "source_text": "This is a fake gazette content. piraporinha and cafundo",
@@ -929,7 +927,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_texts": ["highlight"],
+                "highlight_texts": [],
             },
         ]
 
@@ -990,9 +988,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609977600000],
                     },
@@ -1018,9 +1014,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609977600000],
                     },
@@ -1046,9 +1040,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609545600000],
                     },
@@ -1074,9 +1066,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609545600000],
                     },
@@ -1102,9 +1092,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609459200000],
                     },
@@ -1130,9 +1118,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609459200000],
                     },
@@ -1158,9 +1144,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609372800000],
                     },
@@ -1186,9 +1170,7 @@ class Elasticsearch(TestCase):
                             "state_code": "RJ",
                         },
                         "highlight": {
-                            "source_text": [
-                                "highlight"
-                            ]
+                            "source_text": []
                         },
                         "sort": [1609372800000],
                     },

--- a/tests/elasticsearch_tests.py
+++ b/tests/elasticsearch_tests.py
@@ -153,7 +153,7 @@ class ElasticSearchBaseTestCase(TestCase):
                 d["file_checksum"],
                 d["territory_name"],
                 d["state_code"],
-                d["highlight_text"],
+                d["highlight_texts"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -196,7 +196,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content",
@@ -215,7 +215,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content",
@@ -234,7 +234,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content. anotherkeyword",
@@ -253,7 +253,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content. keyword1",
@@ -272,7 +272,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette with some keywork which is: 000.000.000-00",
@@ -291,7 +291,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content from ID 6",
@@ -310,7 +310,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content from ID 7",
@@ -329,7 +329,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content from ID 8",
@@ -348,7 +348,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content from ID 9",
@@ -367,7 +367,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content from ID 10",
@@ -386,7 +386,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content from ID 11",
@@ -405,7 +405,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
         ]
 
@@ -467,7 +467,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 d["url"],
                 d["territory_name"],
                 d["state_code"],
-                d["highlight_text"],
+                d["highlight_texts"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -519,7 +519,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 d["file_checksum"],
                 d["territory_name"],
                 d["state_code"],
-                d["highlight_text"],
+                d["highlight_texts"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -675,7 +675,7 @@ class ElasticSearchIntegrationBaseTestCase(TestCase):
                 d["file_checksum"],
                 d["territory_name"],
                 d["state_code"],
-                d["highlight_text"],
+                d["highlight_texts"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -719,7 +719,7 @@ class ElasticSearchDataMapperPaginationTest(ElasticSearchIntegrationBaseTestCase
             "territory_id": self.TERRITORY_ID,
             "territory_name": "Rio de Janeiro",
             "state_code": "RJ",
-            "highlight_text": "highlight",
+            "highlight_texts": ["highlight"],
         }
         self._data.append(gazette)
 
@@ -875,7 +875,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content. prefeitura foobar xpto piraporinha",
@@ -893,7 +893,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content. prefeitura, piraporinha and cafundo",
@@ -911,7 +911,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
             {
                 "source_text": "This is a fake gazette content. piraporinha and cafundo",
@@ -929,7 +929,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
-                "highlight_text": "highlight",
+                "highlight_texts": ["highlight"],
             },
         ]
 

--- a/tests/elasticsearch_tests.py
+++ b/tests/elasticsearch_tests.py
@@ -74,7 +74,15 @@ class ElasticSearchBaseTestCase(TestCase):
             "from": offset,
             "size": size,
             "sort": [{"date": {"order": "desc"}}],
+            "highlight": { "fields": { "source_text": {
+                        "fragment_size": 150,
+                        "number_of_fragments": 1,
+                        "type": "unified",
+                        "pre_tags":[""],
+                        "post_tags":[""]
+                    } } },
         }
+
         date_query = {"range": {"date": {}}}
         if since:
             date_query["range"]["date"]["gte"] = since.strftime("%Y-%m-%d")
@@ -116,6 +124,11 @@ class ElasticSearchBaseTestCase(TestCase):
                 "_id": hit["file_checksum"],
                 "_score": None,
                 "_source": hit,
+                "highlight": {
+                    "source_text": [
+                        "highlight"
+                    ]
+                },
             }
             for hit in self._data
         ]
@@ -140,6 +153,7 @@ class ElasticSearchBaseTestCase(TestCase):
                 d["file_checksum"],
                 d["territory_name"],
                 d["state_code"],
+                d["highlight_text"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -182,6 +196,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content",
@@ -200,6 +215,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content",
@@ -218,6 +234,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content. anotherkeyword",
@@ -236,6 +253,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content. keyword1",
@@ -254,6 +272,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette with some keywork which is: 000.000.000-00",
@@ -272,6 +291,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content from ID 6",
@@ -290,6 +310,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content from ID 7",
@@ -308,6 +329,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content from ID 8",
@@ -326,6 +348,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content from ID 9",
@@ -344,6 +367,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content from ID 10",
@@ -362,6 +386,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content from ID 11",
@@ -380,6 +405,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 "state_code": "RJ",
                 "edition_number": "123.456",
                 "is_extra_edition": False,
+                "highlight_text": "highlight",
             },
         ]
 
@@ -441,6 +467,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 d["url"],
                 d["territory_name"],
                 d["state_code"],
+                d["highlight_text"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -492,6 +519,7 @@ class ElasticSearchDataMapperTest(ElasticSearchBaseTestCase):
                 d["file_checksum"],
                 d["territory_name"],
                 d["state_code"],
+                d["highlight_text"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -647,6 +675,7 @@ class ElasticSearchIntegrationBaseTestCase(TestCase):
                 d["file_checksum"],
                 d["territory_name"],
                 d["state_code"],
+                d["highlight_text"],
                 d["edition_number"],
                 d["is_extra_edition"],
             )
@@ -690,6 +719,7 @@ class ElasticSearchDataMapperPaginationTest(ElasticSearchIntegrationBaseTestCase
             "territory_id": self.TERRITORY_ID,
             "territory_name": "Rio de Janeiro",
             "state_code": "RJ",
+            "highlight_text": "highlight",
         }
         self._data.append(gazette)
 
@@ -845,6 +875,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content. prefeitura foobar xpto piraporinha",
@@ -862,6 +893,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content. prefeitura, piraporinha and cafundo",
@@ -879,6 +911,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
+                "highlight_text": "highlight",
             },
             {
                 "source_text": "This is a fake gazette content. piraporinha and cafundo",
@@ -896,6 +929,7 @@ class ElasticSearchDataMapperKeywordTest(ElasticSearchIntegrationBaseTestCase):
                 "processed": False,
                 "territory_name": "Rio de Janeiro",
                 "state_code": "RJ",
+                "highlight_text": "highlight",
             },
         ]
 
@@ -955,6 +989,11 @@ class Elasticsearch(TestCase):
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
                         },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
+                        },
                         "sort": [1609977600000],
                     },
                     {
@@ -977,6 +1016,11 @@ class Elasticsearch(TestCase):
                             "territory_id": "3304557",
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
+                        },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
                         },
                         "sort": [1609977600000],
                     },
@@ -1001,6 +1045,11 @@ class Elasticsearch(TestCase):
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
                         },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
+                        },
                         "sort": [1609545600000],
                     },
                     {
@@ -1023,6 +1072,11 @@ class Elasticsearch(TestCase):
                             "territory_id": "4205920",
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
+                        },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
                         },
                         "sort": [1609545600000],
                     },
@@ -1047,6 +1101,11 @@ class Elasticsearch(TestCase):
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
                         },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
+                        },
                         "sort": [1609459200000],
                     },
                     {
@@ -1069,6 +1128,11 @@ class Elasticsearch(TestCase):
                             "territory_id": "4205920",
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
+                        },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
                         },
                         "sort": [1609459200000],
                     },
@@ -1093,6 +1157,11 @@ class Elasticsearch(TestCase):
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
                         },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
+                        },
                         "sort": [1609372800000],
                     },
                     {
@@ -1115,6 +1184,11 @@ class Elasticsearch(TestCase):
                             "territory_id": "4205920",
                             "territory_name": "Rio de Janeiro",
                             "state_code": "RJ",
+                        },
+                        "highlight": {
+                            "source_text": [
+                                "highlight"
+                            ]
                         },
                         "sort": [1609372800000],
                     },

--- a/tests/gazette_access_tests.py
+++ b/tests/gazette_access_tests.py
@@ -160,7 +160,7 @@ class GazetteAccessTest(TestCase):
                 "state_code": gazette.state_code,
                 "edition": gazette.edition,
                 "is_extra_edition": gazette.is_extra_edition,
-                "highlight_text": gazette.highlight_text,
+                "highlight_texts": gazette.highlight_texts,
             }
             for gazette in self.return_value
         ]
@@ -183,6 +183,7 @@ class GazetteAccessTest(TestCase):
             offset=0,
             size=10,
             fragment_size=150,
+            number_of_fragments=1,
             pre_tags=[''],
             post_tags=[''],
         )
@@ -202,6 +203,7 @@ class GazetteAccessTest(TestCase):
             offset=0,
             size=10,
             fragment_size=150,
+            number_of_fragments=1,
             pre_tags=[''],
             post_tags=[''],
         )
@@ -221,6 +223,7 @@ class GazetteAccessTest(TestCase):
             offset=0,
             size=10,
             fragment_size=150,
+            number_of_fragments=1,
             pre_tags=[''],
             post_tags=[''],
         )
@@ -241,6 +244,7 @@ class GazetteAccessTest(TestCase):
             offset=0,
             size=10,
             fragment_size=150,
+            number_of_fragments=1,
             pre_tags=[''],
             post_tags=[''],
         )
@@ -260,6 +264,7 @@ class GazetteAccessTest(TestCase):
             offset=10,
             size=100,
             fragment_size=150,
+            number_of_fragments=1,
             pre_tags=[''],
             post_tags=[''],
         )
@@ -278,7 +283,7 @@ class GazetteTest(TestCase):
         url = "https://queridodiario.ok.org.br/"
         territory_name = "My city"
         state_code = "My state"
-        highlight_text = "highlight"
+        highlight_texts = ["highlight"]
         edition = "123.45"
         is_extra_edition = False
         checksum = "qweolrjeglkjnasjdowejgorehn"
@@ -289,7 +294,7 @@ class GazetteTest(TestCase):
             checksum,
             territory_name,
             state_code,
-            highlight_text,
+            highlight_texts,
             edition,
             is_extra_edition,
         )
@@ -303,7 +308,7 @@ class GazetteTest(TestCase):
         self.assertEqual(url, gazette.url)
         self.assertEqual(territory_name, gazette.territory_name)
         self.assertEqual(state_code, gazette.state_code)
-        self.assertEqual(highlight_text, gazette.highlight_text)
+        self.assertEqual(highlight_texts, gazette.highlight_texts)
         self.assertEqual(edition, gazette.edition)
         self.assertFalse(gazette.is_extra_edition)
         self.assertEqual(gazette.checksum, checksum)
@@ -314,8 +319,8 @@ class GazetteTest(TestCase):
         checksum = "df;dsfnbkijdasjdasisdsad"
         territory_name = "My city"
         state_code = "My state"
-        highlight_text = "highlight"
-        gazette = Gazette("ID", today, url, checksum, territory_name, state_code, highlight_text)
+        highlight_texts = ["highlight"]
+        gazette = Gazette("ID", today, url, checksum, territory_name, state_code, highlight_texts)
         self.assertIsInstance(
             gazette.territory_id, str, msg="Territory ID should be string"
         )
@@ -326,7 +331,7 @@ class GazetteTest(TestCase):
         self.assertEqual(url, gazette.url)
         self.assertEqual(territory_name, gazette.territory_name)
         self.assertEqual(state_code, gazette.state_code)
-        self.assertEqual(highlight_text, gazette.highlight_text)
+        self.assertEqual(highlight_texts, gazette.highlight_texts)
         self.assertIsNone(gazette.edition)
         self.assertIsNone(gazette.is_extra_edition)
         self.assertEqual(gazette.checksum, checksum)

--- a/tests/gazette_access_tests.py
+++ b/tests/gazette_access_tests.py
@@ -67,6 +67,7 @@ class GazetteAccessTest(TestCase):
                 "so'jsdogjeogjsdogjheogdfsdf",
                 "My city",
                 "My state",
+                "highlight"
                 "123,456",
                 False,
             ),
@@ -77,6 +78,7 @@ class GazetteAccessTest(TestCase):
                 "a;oijaeofdjewofijrogho490jhfeasd",
                 "My city",
                 "My state",
+                "highlight"
                 "123,456",
                 False,
             ),
@@ -87,6 +89,7 @@ class GazetteAccessTest(TestCase):
                 "eolgpijdsfesuhrgfiuhsad",
                 "My city",
                 "My state",
+                "highlight"
                 "123,456",
                 False,
             ),
@@ -97,6 +100,7 @@ class GazetteAccessTest(TestCase):
                 "ew;oigfdfsdjn;dajnorgf",
                 "My city",
                 "My state",
+                "highlight"
                 "123,456",
                 False,
             ),
@@ -107,6 +111,7 @@ class GazetteAccessTest(TestCase):
                 "sdosauiydhbfeicneqiudnewf",
                 "My city",
                 "My state",
+                "highlight"
                 "123,456",
                 False,
             ),
@@ -117,6 +122,7 @@ class GazetteAccessTest(TestCase):
                 "sdo;ifjwefonsdiasndiswabdisbfnidf",
                 "My city",
                 "My state",
+                "highlight"
                 "123,456",
                 False,
             ),
@@ -154,6 +160,7 @@ class GazetteAccessTest(TestCase):
                 "state_code": gazette.state_code,
                 "edition": gazette.edition,
                 "is_extra_edition": gazette.is_extra_edition,
+                "highlight_text": gazette.highlight_text,
             }
             for gazette in self.return_value
         ]
@@ -175,6 +182,9 @@ class GazetteAccessTest(TestCase):
             keywords=None,
             offset=0,
             size=10,
+            fragment_size=150,
+            pre_tags=[''],
+            post_tags=[''],
         )
 
     def test_should_foward_since_date_filter_to_gateway(self):
@@ -191,6 +201,9 @@ class GazetteAccessTest(TestCase):
             keywords=None,
             offset=0,
             size=10,
+            fragment_size=150,
+            pre_tags=[''],
+            post_tags=[''],
         )
 
     def test_should_foward_until_date_filter_to_gateway(self):
@@ -207,6 +220,9 @@ class GazetteAccessTest(TestCase):
             keywords=None,
             offset=0,
             size=10,
+            fragment_size=150,
+            pre_tags=[''],
+            post_tags=[''],
         )
 
     def test_should_foward_keywords_filter_to_gateway(self):
@@ -224,6 +240,9 @@ class GazetteAccessTest(TestCase):
             keywords=keywords,
             offset=0,
             size=10,
+            fragment_size=150,
+            pre_tags=[''],
+            post_tags=[''],
         )
 
     def test_should_foward_page_fields_filter_to_gateway(self):
@@ -240,6 +259,9 @@ class GazetteAccessTest(TestCase):
             keywords=None,
             offset=10,
             size=100,
+            fragment_size=150,
+            pre_tags=[''],
+            post_tags=[''],
         )
 
 
@@ -256,6 +278,7 @@ class GazetteTest(TestCase):
         url = "https://queridodiario.ok.org.br/"
         territory_name = "My city"
         state_code = "My state"
+        highlight_text = "highlight"
         edition = "123.45"
         is_extra_edition = False
         checksum = "qweolrjeglkjnasjdowejgorehn"
@@ -266,6 +289,7 @@ class GazetteTest(TestCase):
             checksum,
             territory_name,
             state_code,
+            highlight_text,
             edition,
             is_extra_edition,
         )
@@ -279,6 +303,7 @@ class GazetteTest(TestCase):
         self.assertEqual(url, gazette.url)
         self.assertEqual(territory_name, gazette.territory_name)
         self.assertEqual(state_code, gazette.state_code)
+        self.assertEqual(highlight_text, gazette.highlight_text)
         self.assertEqual(edition, gazette.edition)
         self.assertFalse(gazette.is_extra_edition)
         self.assertEqual(gazette.checksum, checksum)
@@ -289,7 +314,8 @@ class GazetteTest(TestCase):
         checksum = "df;dsfnbkijdasjdasisdsad"
         territory_name = "My city"
         state_code = "My state"
-        gazette = Gazette("ID", today, url, checksum, territory_name, state_code)
+        highlight_text = "highlight"
+        gazette = Gazette("ID", today, url, checksum, territory_name, state_code, highlight_text)
         self.assertIsInstance(
             gazette.territory_id, str, msg="Territory ID should be string"
         )
@@ -300,6 +326,7 @@ class GazetteTest(TestCase):
         self.assertEqual(url, gazette.url)
         self.assertEqual(territory_name, gazette.territory_name)
         self.assertEqual(state_code, gazette.state_code)
+        self.assertEqual(highlight_text, gazette.highlight_text)
         self.assertIsNone(gazette.edition)
         self.assertIsNone(gazette.is_extra_edition)
         self.assertEqual(gazette.checksum, checksum)


### PR DESCRIPTION
@jvanz @sergiomario 

- use list instead single match

# Prepare application

- run application
- add more a city with large source text for manual tests:
```shell
curl -X POST 'localhost:9200/gazettes/_doc/abc?pretty' -H 'Content-Type: application/json' -d'{
  "source_text": "Uma força-tarefa iniciou ontem, dia 25, em 13 estações do BRT Transoeste, a primeira fase da operação de ordenamento, que vai combater ações irregulares nos ônibus articulados e nas estações. Serão coibidos calotes e o comércio ilegal tanto dentro quanto no entorno das paradas, além de acolhimento de moradores de rua. As ações para solucionar os problemas do sistema BRT foram anunciadas nesta segunda-feira pelo prefeito Marcelo Crivella, que decretou a intervenção no dia 29 passado. - Na intervenção do BRT chegou o momento das ações importantes. Primeiro, o recapeamento da calha. Tem vários trechos que estão diminuindo a velocidade dos ônibus e transformando a viagem numa coisa muito desconfortável. Outra Edvaldo Reis coisa, nós precisamos acabar com a evasão. Ela é injusta, faz com que o sistema fique O outro problema que já começou a ser enfrentado é o da pavimentação da calha por onde circulam os ônibus artiComeça repavimentação na via expressa Crivella recebe novos residentes dos hospitais e promove ações na saúde O prefeito Marcelo Crivella abriu ontem, no Museu do Amanhã, o Programa de Residências em Saúde da Prefeitura do Rio. São 416 novos médicos, enfermeiros e profissionais de saúde mental residentes que chegam para reforçar as equipes dos hospitais e institutos da rede municipal. No mesmo evento, Crivella anunciou, com a secretária municipal de Saúde, Beatriz Busch, a ampliação da oferta de métodos contraceptivos na rede pública da cidade. E ainda apresentou um balanço sobre o primeiro ano de gestão da Empresa Pública de Saúde do Rio de Janeiro (RioSaúde) no Hospital Municipal Rocha Faria, em Campo Grande. No período, o número de atendimentos cresceu, assim como a aprovação da população: 84% dos usuários hoje recomendam a unidade. – O Rio se engrandece e se dignifica hoje com a presença de centenas de residentes que começam a atuar em nossos hospitais públicos. Também estamos festejando mais de 180 mil atendimentos que foram feitos no Rocha Faria depois que a RioSaúde o assumiu – destacou o prefeito, que concluiu: – Nossa secretária lançou hoje um programa muito importante, que vai ajudar as mulheres a fazer planejamento familiar com o DIU, o Dispositivo Intrauterino de cobre, que, colocado no útero, evita gravidez indesejada. No Rio nascem 80 mil bebês por ano, uns 50 mil na rede pública, e em mais da metade dos casos as mães não estavam preparadas para engravidar. O DIU é um dispositivo não abortivo, sem contraindicação para a mulher, pode ser usado por dez anos e vai ser colocado nas clínicas de família ou nas maternidades, logo depois do parto, se a mulher assim desejar. Rocha Faria aumenta número de atendimentos O Hospital Rocha Faria voltou a ser referência na Zona Oeste, após sofrer um choque de gestão com a saída da organização social que o administrava. Em um ano, a RioSaúde fez aumentar o número de atendimentos e a aprovação da população. Foram 182.842 acolhimentos em 2018, com média mensal de internações 66% maior do que em 2017 e 7% mais cirurgias do que no ano anterior. O tempo médio de espera pela consulta caiu para menos de 50 minutos, mesmo padrão da rede privada. E os casos graves são atendidos na hora. Haverá combate ao calote e ao comércio ilegal em 13 estações e recuperação de vias expressas para ônibus inviável economicamente, não há troca de ônibus, nem modernização. Então, precisamos que as pessoas que andam de BRT paguem como todos. Também vamos reprimir o comércio ilegal nas estações. O comércio só pode ser feito se estiver regularizado - afirmou Crivella. As equipes da Guarda Municipal, da Comlurb, da Coordenadoria de Controle Urbano e das secretarias de Ordem Pública, de Conservação e Meio Ambiente, de Transportes e da Assistência Social e Direitos Humanos se reuniram no Centro de Controle Operacional do BRT, na Barra da Tijuca, e de lá partiram para a estação Salvador Allende, no Recreio. A ação de ordenamento desmontou barracas e apreendeu o material vendido irregularmente dentro e fora do terminal. culados. O processo de recuperação de vias expressas do BRT, com a fresagem e repavimentação emergencial dos trechos mais críticos da faixa de rolagem dos ônibus, teve início na noite de sábado, dia 23. Falhas no projeto do corredor Transoeste, inaugurado em 2012, levaram à utilização de materiais e técnicas inadequados para o solo da região, o que provoca constantes depressões e elevações na pista, danificando os veículos.",
  "date": "2021-04-21",
  "power": "executive",
  "file_checksum": "2566f0e0ff98d899ee0633da64bc65e56",
  "file_path": "3304557/2019-02-26/c942328486185aa09ec19a7c723b3a33847258ee",
  "file_url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
  "url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
  "scraped_at": "2020-10-30T07:04:29.796347",
  "created_at": "2020-10-30T07:05:33.094289",
  "territory_id": "3304557",
  "territory_name": "Rio de Janeiro",
  "state_code": "RJ",
  "edition_number": "123.45",
  "is_extra_edition": "false"
}'
```

# tests without territory filter
- [search for](http://localhost:8080/gazettes?keywords=aumentar&size=10&fragment_size=150&pre_tags=%3Cb%3E&post_tags=%3C%2Fb%3E) `aumentar`
- [ ] should return hightlight text
```json
{
  "total_gazettes": 1,
  "gazettes": [
    {
      "territory_id": "3304557",
      "date": "2021-04-21",
      "edition": "123.45",
      "url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
      "territory_name": "Rio de Janeiro",
      "state_code": "RJ",
      "highlight_texts": ["Em um ano, a RioSaúde fez <b>aumentar</b> o número de atendimentos e a aprovação da população."],
      "is_extra_edition": false
    }
  ]
}
```

- [search for](http://localhost:8080/gazettes?keywords=aumentar&size=10) `aumentar` without tags parameters
- [ ] should return hightlight text without markup
```json
{
    "gazettes": [
        {
            "territory_id": "3304557",
            "date": "2021-04-21",
            "edition": "123.45",
            "url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
            "territory_name": "Rio de Janeiro",
            "state_code": "RJ",
            "highlight_texts": ["Em um ano, a RioSaúde fez aumentar o número de atendimentos e a aprovação da população."],
            "is_extra_edition": false
        }
    ],
    "total_gazettes": 1
}
```

# tests with territory filter
- [search for](http://localhost:8080/gazettes/3304557?keywords=aumentar&size=10&fragment_size=150&pre_tags=%3Cb%3E&post_tags=%3C%2Fb%3E) `aumentar`
- [ ] should return hightlight text
```json
{
  "total_gazettes": 1,
  "gazettes": [
    {
      "territory_id": "3304557",
      "date": "2021-04-21",
      "edition": "123.45",
      "url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
      "territory_name": "Rio de Janeiro",
      "state_code": "RJ",
      "highlight_texts": ["Em um ano, a RioSaúde fez <b>aumentar</b> o número de atendimentos e a aprovação da população."],
      "is_extra_edition": false
    }
  ]
}
```

- [search for](http://localhost:8080/gazettes/3304557?keywords=aumentar&size=10) `aumentar` without tags parameters
- [ ] should return hightlight text without markup
```json
{
    "gazettes": [
        {
            "territory_id": "3304557",
            "date": "2021-04-21",
            "edition": "123.45",
            "url": "https://doweb.rio.rj.gov.br/portal/edicoes/download/4067",
            "territory_name": "Rio de Janeiro",
            "state_code": "RJ",
            "highlight_texts": ["Em um ano, a RioSaúde fez aumentar o número de atendimentos e a aprovação da população."],
            "is_extra_edition": false
        }
    ],
    "total_gazettes": 1
}
```

