### PR TITLE
add sort by parameter

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -61,6 +61,13 @@ class CitiesSearchResponse(BaseModel):
     cities: List[City]
 
 
+@unique
+class SortBy(str, Enum):
+    RELEVANCE = "relevance"
+    DESCENDING_DATE = "descending_date"
+    ASCENDING_DATE = "ascending_date"
+
+
 def trigger_gazettes_search(
     territory_id: str = None,
     since: date = None,
@@ -72,7 +79,7 @@ def trigger_gazettes_search(
     number_of_fragments: int = 1,
     pre_tags: List[str] = [""],
     post_tags: List[str] = [""],
-    sort_by: str = "descending_date",
+    sort_by: SortBy = SortBy.DESCENDING_DATE,
 ):
     gazettes_count, gazettes = app.gazettes.get_gazettes(
         GazetteRequest(
@@ -86,7 +93,7 @@ def trigger_gazettes_search(
             number_of_fragments=number_of_fragments,
             pre_tags=pre_tags,
             post_tags=post_tags,
-            sort_by=sort_by,
+            sort_by=sort_by.value,
         )
     )
     response = {
@@ -151,8 +158,8 @@ async def get_gazettes(
         title="Post tags of fragments of highlight.",
         description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
-    sort_by: Optional[str] = Query(
-        "descending_date",
+    sort_by: Optional[SortBy] = Query(
+        SortBy.DESCENDING_DATE,
         title="Allow the user to define the order of the search results.",
         description="Allow the user to define the order of the search results. The API should allow 3 types: relevance, descending_date, ascending_date",
     ),
@@ -225,8 +232,8 @@ async def get_gazettes_by_territory_id(
         title="Post tags of fragments of highlight.",
         description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
-    sort_by: Optional[str] = Query(
-        "descending_date",
+    sort_by: Optional[SortBy] = Query(
+        SortBy.DESCENDING_DATE,
         title="Allow the user to define the order of the search results.",
         description="Allow the user to define the order of the search results. The API should allow 3 types: relevance, descending_date, ascending_date",
     ),

--- a/api/api.py
+++ b/api/api.py
@@ -72,6 +72,7 @@ def trigger_gazettes_search(
     number_of_fragments: int = 1,
     pre_tags: List[str] = [""],
     post_tags: List[str] = [""],
+    sort_by: str = "descending_date",
 ):
     gazettes_count, gazettes = app.gazettes.get_gazettes(
         GazetteRequest(
@@ -85,6 +86,7 @@ def trigger_gazettes_search(
             number_of_fragments=number_of_fragments,
             pre_tags=pre_tags,
             post_tags=post_tags,
+            sort_by=sort_by,
         )
     )
     response = {
@@ -149,6 +151,11 @@ async def get_gazettes(
         title="Post tags of fragments of highlight.",
         description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
+    sort_by: Optional[str] = Query(
+        "descending_date",
+        title="Allow the user to define the order of the search results.",
+        description="Allow the user to define the order of the search results. The API should allow 3 types: relevance, descending_date, ascending_date",
+    ),
 ):
     return trigger_gazettes_search(
         None,
@@ -161,6 +168,7 @@ async def get_gazettes(
         number_of_fragments,
         pre_tags,
         post_tags,
+        sort_by,
     )
 
 
@@ -217,6 +225,11 @@ async def get_gazettes_by_territory_id(
         title="Post tags of fragments of highlight.",
         description="Post tags of fragments of highlight. This is a list of strings (usually HTML tags) that will appear after the text which matches the query",
     ),
+    sort_by: Optional[str] = Query(
+        "descending_date",
+        title="Allow the user to define the order of the search results.",
+        description="Allow the user to define the order of the search results. The API should allow 3 types: relevance, descending_date, ascending_date",
+    ),
 ):
     return trigger_gazettes_search(
         territory_id,
@@ -229,6 +242,7 @@ async def get_gazettes_by_territory_id(
         number_of_fragments,
         pre_tags,
         post_tags,
+        sort_by,
     )
 
 

--- a/gazettes/gazette_access.py
+++ b/gazettes/gazette_access.py
@@ -22,6 +22,7 @@ class GazetteRequest:
         number_of_fragments: int = 1,
         pre_tags: List[str] = [""],
         post_tags: List[str] = [""],
+        sort_by: str = "descending_date",
     ):
         self.territory_id = territory_id
         self.since = since
@@ -33,6 +34,7 @@ class GazetteRequest:
         self.number_of_fragments = number_of_fragments
         self.pre_tags = pre_tags
         self.post_tags = post_tags
+        self.sort_by = sort_by
 
 
 class GazetteDataGateway(abc.ABC):
@@ -52,6 +54,7 @@ class GazetteDataGateway(abc.ABC):
         number_of_fragments: int = 1,
         pre_tags: List[str] = [""],
         post_tags: List[str] = [""],
+        sort_by: str = "descending_date",
     ):
         """
         Method to get the gazette from storage
@@ -108,6 +111,7 @@ class GazetteAccess(GazetteAccessInterface):
         number_of_fragments = filters.number_of_fragments if filters is not None else 1
         pre_tags = filters.pre_tags if filters is not None else [""]
         post_tags = filters.post_tags if filters is not None else [""]
+        sort_by = filters.sort_by if filters is not None else "descending_date"
         total_number_gazettes, gazettes = self._index_gateway.get_gazettes(
             territory_id=territory_id,
             since=since,
@@ -119,6 +123,7 @@ class GazetteAccess(GazetteAccessInterface):
             number_of_fragments=number_of_fragments,
             pre_tags=pre_tags,
             post_tags=post_tags,
+            sort_by=sort_by,
         )
         return (total_number_gazettes, [vars(gazette) for gazette in gazettes])
 

--- a/tests/test_gazette_access.py
+++ b/tests/test_gazette_access.py
@@ -234,6 +234,7 @@ class GazetteAccessTest(TestCase):
             number_of_fragments=1,
             pre_tags=[""],
             post_tags=[""],
+            sort_by="descending_date",
         )
 
     def test_should_foward_since_date_filter_to_gateway(self):
@@ -256,6 +257,7 @@ class GazetteAccessTest(TestCase):
             number_of_fragments=1,
             pre_tags=[""],
             post_tags=[""],
+            sort_by="descending_date",
         )
 
     def test_should_foward_until_date_filter_to_gateway(self):
@@ -278,6 +280,7 @@ class GazetteAccessTest(TestCase):
             number_of_fragments=1,
             pre_tags=[""],
             post_tags=[""],
+            sort_by="descending_date",
         )
 
     def test_should_foward_keywords_filter_to_gateway(self):
@@ -301,6 +304,7 @@ class GazetteAccessTest(TestCase):
             number_of_fragments=1,
             pre_tags=[""],
             post_tags=[""],
+            sort_by="descending_date",
         )
 
     def test_should_foward_page_fields_filter_to_gateway(self):
@@ -323,6 +327,7 @@ class GazetteAccessTest(TestCase):
             number_of_fragments=1,
             pre_tags=[""],
             post_tags=[""],
+            sort_by="descending_date",
         )
 
 


### PR DESCRIPTION
closes #27 

cc @giuliocc @jvanz 

This simple version allow front to use all sort options

# Test

Use the new parameter `sort_by` for search by:
- [ ] [relevance (elasticsearch relevance)](http://localhost:8080/gazettes/?keywords=hospital&sort_by=relevance)
- [ ] [date by descending](http://localhost:8080/gazettes/?keywords=hospital&sort_by=date_by_descending)
- [ ] [ascending order](http://localhost:8080/gazettes/?keywords=hospital&sort_by=date_by_ascending)

And do the same with some city:
- [ ] [relevance (elasticsearch relevance)](http://localhost:8080/gazettes/4205407?keywords=hospital&sort_by=relevance)
- [ ] [date by descending](http://localhost:8080/gazettes/4205407?keywords=hospital&sort_by=date_by_descending)
- [ ] [ascending order](http://localhost:8080/gazettes/4205407?keywords=hospital&sort_by=date_by_ascending)