### PR TITLE
Adds CORS configuration options

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -7,6 +7,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from gazettes import GazetteAccessInterface, GazetteRequest
+from config.config import load_configuration
+
+config = load_configuration()
 
 app = FastAPI(
     title="Querido Diário",
@@ -14,13 +17,12 @@ app = FastAPI(
     version="0.10.0",
 )
 
-# TODO load CORS configuration. Do NOT allow any origin.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=config.cors_allow_origins,
+    allow_credentials=config.cors_allow_credentials,
+    allow_methods=config.cors_allow_methods,
+    allow_headers=config.cors_allow_headers,
 )
 
 

--- a/config/config.py
+++ b/config/config.py
@@ -1,12 +1,53 @@
 import os
 
 
+VALID_BOOLEAN_TRUE_VALUES = [True, "True", "TRUE"]
+VALID_BOOLEAN_FALSE_VALUES = [False, "False", "FALSE"]
+VALID_BOOLEAN_VALUES = VALID_BOOLEAN_TRUE_VALUES + VALID_BOOLEAN_FALSE_VALUES
+
+
 class Configuration:
     def __init__(self):
         self.host = os.environ.get("QUERIDO_DIARIO_ELASTICSEARCH_HOST", "")
         self.index = os.environ.get("QUERIDO_DIARIO_ELASTICSEARCH_INDEX", "")
         self.root_path = os.environ.get("QUERIDO_DIARIO_API_ROOT_PATH", "")
         self.url_prefix = os.environ.get("QUERIDO_DIARIO_URL_PREFIX", "")
+        self.cors_allow_origins = Configuration._load_list(
+            "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS", ["*"]
+        )
+        self.cors_allow_credentials = Configuration._load_boolean(
+            "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS", True
+        )
+        self.cors_allow_methods = Configuration._load_list(
+            "QUERIDO_DIARIO_CORS_ALLOW_METHODS", ["*"]
+        )
+        self.cors_allow_headers = Configuration._load_list(
+            "QUERIDO_DIARIO_CORS_ALLOW_HEADERS", ["*"]
+        )
+
+    @classmethod
+    def _load_list(cls, key, default=[]):
+        value = os.environ.get(key, default)
+        if isinstance(value, list):
+            return value
+        return value.split(",")
+
+    @classmethod
+    def _is_true(cls, value):
+        return value in VALID_BOOLEAN_TRUE_VALUES
+
+    @classmethod
+    def _is_false(cls, value):
+        return value in VALID_BOOLEAN_FALSE_VALUES
+
+    @classmethod
+    def _load_boolean(cls, key, default=False):
+        value = os.environ.get(key, default)
+        if cls._is_true(value):
+            return True
+        if cls._is_false(value):
+            return False
+        return default
 
 
 def load_configuration():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,22 @@ class BasicConfigurationTests(TestCase):
             expected_values["QUERIDO_DIARIO_URL_PREFIX"],
             msg="Invalid URL prefix",
         )
+        self.assertEqual(
+            configuration.cors_allow_origins,
+            expected_values["QUERIDO_DIARIO_CORS_ALLOW_ORIGINS"],
+        )
+        self.assertEqual(
+            configuration.cors_allow_credentials,
+            expected_values["QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS"],
+        )
+        self.assertEqual(
+            configuration.cors_allow_methods,
+            expected_values["QUERIDO_DIARIO_CORS_ALLOW_METHODS"],
+        )
+        self.assertEqual(
+            configuration.cors_allow_headers,
+            expected_values["QUERIDO_DIARIO_CORS_ALLOW_HEADERS"],
+        )
 
     @patch.dict(
         "os.environ", {}, True,
@@ -37,6 +53,10 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "",
             "QUERIDO_DIARIO_API_ROOT_PATH": "",
             "QUERIDO_DIARIO_URL_PREFIX": "",
+            "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": ["*"],
+            "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": True,
+            "QUERIDO_DIARIO_CORS_ALLOW_METHODS": ["*"],
+            "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": ["*"],
         }
         configuration = load_configuration()
         self.check_configuration_values(configuration, expected_config_dict)
@@ -48,6 +68,10 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "",
             "QUERIDO_DIARIO_API_ROOT_PATH": "",
             "QUERIDO_DIARIO_URL_PREFIX": "",
+            "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": "",
+            "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": "",
+            "QUERIDO_DIARIO_CORS_ALLOW_METHODS": "",
+            "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": "",
         },
         True,
     )
@@ -57,6 +81,10 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "",
             "QUERIDO_DIARIO_API_ROOT_PATH": "",
             "QUERIDO_DIARIO_URL_PREFIX": "",
+            "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": [""],
+            "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": True,
+            "QUERIDO_DIARIO_CORS_ALLOW_METHODS": [""],
+            "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": [""],
         }
         configuration = load_configuration()
         self.check_configuration_values(configuration, expected_config_dict)
@@ -68,6 +96,10 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "myindex",
             "QUERIDO_DIARIO_API_ROOT_PATH": "api/",
             "QUERIDO_DIARIO_URL_PREFIX": "https://test.com",
+            "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": "localhost",
+            "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": "True",
+            "QUERIDO_DIARIO_CORS_ALLOW_METHODS": "GET,POST",
+            "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": "X-Test-Test",
         },
         True,
     )
@@ -77,6 +109,10 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_ELASTICSEARCH_INDEX": "myindex",
             "QUERIDO_DIARIO_API_ROOT_PATH": "api/",
             "QUERIDO_DIARIO_URL_PREFIX": "https://test.com",
+            "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": ["localhost"],
+            "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": True,
+            "QUERIDO_DIARIO_CORS_ALLOW_METHODS": ["GET", "POST"],
+            "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": ["X-Test-Test"],
         }
         configuration = load_configuration()
         self.check_configuration_values(configuration, expected_config_dict)


### PR DESCRIPTION
Fixes #36 by adding configuration options for custom CORS rules:
- QUERIDO_DIARIO_CORS_ALLOW_ORIGINS
- QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS
- QUERIDO_DIARIO_CORS_ALLOW_METHODS
- QUERIDO_DIARIO_CORS_ALLOW_HEADERS