### PR TITLE
[WIP] Cache podman layers in GitHub workflows (#12)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ jobs:
     name: Build and test latest code changes
     runs-on: ubuntu-latest
     steps:
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          key: querido-diario-cache
+          path: |
+            ~/.local/share/containers
+
       - name: Checkout source code
         uses: actions/checkout@master
 

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -13,6 +13,13 @@ jobs:
     name: Release tag
     runs-on: ubuntu-latest
     steps:
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          key: querido-diario-cache
+          path: |
+            ~/.local/share/containers
+
       - name: Checkout source code
         uses: actions/checkout@master
 

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -10,6 +10,13 @@ jobs:
     name: Build, test and show code coverage
     runs-on: ubuntu-latest
     steps:
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          key: querido-diario-cache
+          path: |
+            ~/.local/share/containers
+
       - name: Checkout source code
         uses: actions/checkout@master
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt && rm requirements.txt
 
 RUN mkdir /mnt/code
-COPY . /mnt/code
 WORKDIR /mnt/code
 ENV PYTHONPATH=/mnt/code
 
 ADD https://querido-diario.nyc3.cdn.digitaloceanspaces.com/censo/censo.csv censo.csv
 RUN chmod 644 censo.csv
+
+COPY . /mnt/code
 
 USER gazette


### PR DESCRIPTION
I enabled GitHub caching for podman's layer cache folder
(`~/.local/share/containers/`) and reordered the commands in the
Dockerfile to optimize the cache usage by keeping the things that change
the most (i.e. the code) in the last build steps.

GitHub will automatically delete the cache if it's unused after a few
days.