### PR TITLE
Atualiza Makefile para compatibilidade no MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ wait-for=(podman run --rm -ti --volume $(PWD):/mnt/code:rw \
 	--pod $(POD_NAME) \
 	--env PYTHONPATH=/mnt/code \
 	--user=$(UID):$(UID) \
-	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) wait-for-it --timeout=30 $1)
+	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) wait-for-it --timeout=40 $1)
 
 .PHONY: black
 black:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ destroy-pod:
 	podman pod rm --force --ignore $(POD_NAME)
 
 create-pod: destroy-pod
-	cp --no-clobber config/sample.env config/current.env
+	rsync --ignore-existing config/sample.env config/current.env
 	podman pod create --publish $(API_PORT):$(API_PORT) \
 	  --publish $(ELASTICSEARCH_PORT1):$(ELASTICSEARCH_PORT1) \
 	  --publish $(ELASTICSEARCH_PORT2):$(ELASTICSEARCH_PORT2) \


### PR DESCRIPTION
Pessoal tentei rodar o projeto localmente (MacOS 12.6) e tive que fazer algumas alterações no `Makefile` pra conseguir:

1. Comando `cp` com a opção `--no-clobber` não existe:
```
➜  querido-diario-api git:(main) ✗ make run
podman pod rm --force --ignore querido-diario-api
e464f3ad24898b7b4433568f8f9b43692919a744bc674b96a8e07015c8b27dee
cp --no-clobber config/sample.env config/current.env
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file ... target_directory
make: *** [create-pod] Error 64
```

Como alternativa, podemos usar o comando `rsync` com a opção `--ignore-existing` que é compatível com outras distribuições Unix

2. Elasticsearch local demorando mais de 30 segundos pra responder. Nesse caso só aumentei o timeout para 40 segundos:
```
➜  querido-diario-api git:(main) ✗ make elasticsearch
podman rm --force --ignore querido-diario-api-elasticsearch
c8e1025559339fc2373270f0c256e5d2f0a7816dd1c7496d79c37fec56c6c92d
podman run -d --rm -ti \
		--name querido-diario-api-elasticsearch \
		--pod querido-diario-api \
		--env discovery.type=single-node \
		elasticsearch:7.9.1
9a7d7b9d13257810b42c2209a3b8e8c27a4e9f3168e8b2d19136df8a1010c596
(podman run --rm -ti --volume /Users/fabio.hiroki/personalSites/querido-diario-api:/mnt/code:rw --pod querido-diario-api --env PYTHONPATH=/mnt/code --user=: serenata/querido-diario-api:latest wait-for-it --timeout=40  localhost:9200)
wait-for-it: waiting 40 seconds for localhost:9200
wait-for-it: localhost:9200 is available after 33 seconds
```