### PR TITLE
adição do load-data ao comando run e atualização do README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ wait-for=(podman run --rm -ti --volume $(PWD):/mnt/code:rw \
 	--pod $(POD_NAME) \
 	--env PYTHONPATH=/mnt/code \
 	--user=$(UID):$(UID) \
-	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) wait-for-it --timeout=30 $1)
+	$(IMAGE_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG) wait-for-it --timeout=90 $1)
 
 .PHONY: black
 black:
@@ -124,7 +124,7 @@ shell:
 		bash
 
 .PHONY: run
-run: create-pod opensearch database re-run
+run: create-pod opensearch database load-data re-run
 
 .PHONY:load-data
 load-data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,9 +59,9 @@ make run
 
 Esse comando iniciará todos os contêineres necessários para executar a API. Ou seja, ele inicializa o banco de dados e o contêiner da API. Se tudo correr bem, você poderá fazer consultas à API em `localhost:8080/gazettes/<City IBGE Code>`
 
-> ATENÇÃO: Quando você precisar reiniciar a API, apenas interrompa o processo da API e execute o `make rerun` novamente. Não é necessário reiniciar o banco de dados.
+> ATENÇÃO: Quando você precisar reiniciar a API, apenas interrompa o processo da API e execute o `make re-run` novamente. Não é necessário reiniciar o banco de dados.
 
-Você pode checar toda a documentação interativa da API em  `localhost:8080/docs`. Nessa página, você pode fazer requisições à API diretamente. Mas, para vê-la funcionar, você precisa inserir dados no índice. Há outro comando, `make load-data`, que insere alguns exemplos de entrada no índice principal.
+Você pode checar toda a documentação interativa da API em  `localhost:8080/docs`. Nessa página, você pode fazer requisições à API diretamente.
 
 ## Usando o endpoint de ‘sugestões’
 


### PR DESCRIPTION
Este pull request faz as seguintes alterações:

**Makefile:**

Adiciona o comando `load-data` ao target .PHONY: run. Isso garante que, ao executar `make run`, os dados necessários sejam carregados corretamente, melhorando a inicialização do ambiente.

**README:**

Remove a referência ao comando `make load-data`, que agora está integrado ao comando `run`.
Corrige o comando `make rerun` para `make re-run `para refletir a sintaxe correta no Makefile.

## Alterações detalhadas

**Makefile:**

```makefile
.PHONY: run
run: create-pod opensearch database load-data re-run
```

**README:**

* Removido o texto que fazia referência ao comando make load-data.
* Alterado make rerun para make re-run na documentação.