### PR TITLE
Refatoração dos testes

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,5 +1,5 @@
 import os
-
+from typing import Optional, Union
 
 VALID_BOOLEAN_TRUE_VALUES = [True, "True", "TRUE"]
 VALID_BOOLEAN_FALSE_VALUES = [False, "False", "FALSE"]
@@ -44,7 +44,7 @@ class Configuration:
         self.suggestion_mailjet_custom_id = os.environ.get(
             "QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID", ""
         )
-        self.city_database_file = os.environ["CITY_DATABASE_CSV"]
+        self.city_database_file = os.environ.get("CITY_DATABASE_CSV", "")
         self.gazette_index = os.environ.get("GAZETTE_OPENSEARCH_INDEX", "")
         self.gazette_content_field = os.environ.get("GAZETTE_CONTENT_FIELD", "")
         self.gazette_content_exact_field_suffix = os.environ.get(
@@ -57,7 +57,7 @@ class Configuration:
         self.gazette_territory_id_field = os.environ.get(
             "GAZETTE_TERRITORY_ID_FIELD", ""
         )
-        self.themes_database_file = os.environ["THEMES_DATABASE_JSON"]
+        self.themes_database_file = os.environ.get("THEMES_DATABASE_JSON","")
         self.themed_excerpt_content_field = os.environ.get(
             "THEMED_EXCERPT_CONTENT_FIELD", ""
         )
@@ -85,12 +85,8 @@ class Configuration:
         self.themed_excerpt_tfidf_score_field = os.environ.get(
             "THEMED_EXCERPT_TFIDF_SCORE_FIELD", ""
         )
-        self.themed_excerpt_fragment_size = int(
-            os.environ.get("THEMED_EXCERPT_FRAGMENT_SIZE", 10000)
-        )
-        self.themed_excerpt_number_of_fragments = int(
-            os.environ.get("THEMED_EXCERPT_NUMBER_OF_FRAGMENTS", 1)
-        )
+        self.themed_excerpt_fragment_size = Configuration._to_number("THEMED_EXCERPT_FRAGMENT_SIZE", 10000)
+        self.themed_excerpt_number_of_fragments = Configuration._to_number("THEMED_EXCERPT_NUMBER_OF_FRAGMENTS", 1)
         self.companies_database_host = os.environ.get("POSTGRES_COMPANIES_HOST", "")
         self.companies_database_db = os.environ.get("POSTGRES_COMPANIES_DB", "")
         self.companies_database_user = os.environ.get("POSTGRES_COMPANIES_USER", "")
@@ -101,31 +97,43 @@ class Configuration:
         self.aggregates_database_host = os.environ.get("POSTGRES_AGGREGATES_HOST", "")
         self.aggregates_database_db = os.environ.get("POSTGRES_AGGREGATES_DB", "")
         self.aggregates_database_user = os.environ.get("POSTGRES_AGGREGATES_USER", "")
-        self.aggregates_database_pass = os.environ.get("POSTGRES_AGGREGATES_PASSWORD", "")
+        self.aggregates_database_pass = os.environ.get(
+            "POSTGRES_AGGREGATES_PASSWORD", ""
+        )
         self.aggregates_database_port = os.environ.get("POSTGRES_AGGREGATES_PORT", "")
+
     @classmethod
-    def _load_list(cls, key, default=[]):
+    def _load_list(cls, key:str, default:list=[]) -> list:
         value = os.environ.get(key, default)
         if isinstance(value, list):
             return value
         return value.split(",")
 
     @classmethod
-    def _is_true(cls, value):
+    def _is_true(cls, value: Union[str, bool]) -> bool:
         return value in VALID_BOOLEAN_TRUE_VALUES
 
     @classmethod
-    def _is_false(cls, value):
+    def _is_false(cls, value: Union[str, bool]) -> bool:
         return value in VALID_BOOLEAN_FALSE_VALUES
 
     @classmethod
-    def _load_boolean(cls, key, default=False):
+    def _load_boolean(cls, key:str, default:bool=False) -> bool:
         value = os.environ.get(key, default)
         if cls._is_true(value):
             return True
         if cls._is_false(value):
             return False
         return default
+
+    @classmethod
+    def _to_number(cls, key:str, default:int=0) -> int:
+        value = os.environ.get(key, default=0)
+        if not bool(value and not value.isspace()):
+            return default
+        if not value.isdigit():
+            return default
+        return int(value) 
 
 
 def load_configuration():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,17 @@
-from datetime import date, timedelta
-from unittest.mock import MagicMock
+from datetime import date, timedelta, datetime
+from unittest.mock import MagicMock, patch
 from unittest import TestCase, expectedFailure
 
 from fastapi.testclient import TestClient
 
 from api import app, configure_api_app
+
 from gazettes import GazetteAccessInterface, GazetteRequest
 from suggestions import Suggestion, SuggestionSent, SuggestionServiceInterface
 from companies import CompaniesAccessInterface
+from aggregates import AggregatesAccessInterface
+from themed_excerpts import ThemedExcerptAccessInterface
+from cities import CityAccessInterface
 
 
 @GazetteAccessInterface.register
@@ -25,15 +29,44 @@ class MockCompaniesAccessInterface:
     pass
 
 
+@AggregatesAccessInterface.register
+class MockAggregatesAccessInterface:
+    pass
+
+
+@ThemedExcerptAccessInterface.register
+class MockThemedExcerptAccessInterface:
+    pass
+
+
+@CityAccessInterface.register
+class MockCityAccessInterface:
+    pass
+
+
 class ApiGazettesEndpointTests(TestCase):
     def create_mock_gazette_interface(
-        self, return_value=(0, []), cities_info=[], city_info=None
+        self, 
+        return_value=(0, []), 
+        cities_info=[], 
+        city_info=None
     ):
         interface = MockGazetteAccessInterface()
         interface.get_gazettes = MagicMock(return_value=return_value)
-        interface.get_cities = MagicMock(return_value=cities_info)
-        interface.get_city = MagicMock(return_value=city_info)
+        interface.get_cities   = MagicMock(return_value=cities_info)
+        interface.get_city     = MagicMock(return_value=city_info)
         return interface
+
+    def get_test_client(self):
+        configure_api_app(
+            gazettes=self.create_mock_gazette_interface(),
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(),
+        )
+        return TestClient(app)
 
     def test_api_should_fail_when_try_to_set_any_object_as_gazettes_interface(self):
         with self.assertRaises(Exception):
@@ -43,146 +76,217 @@ class ApiGazettesEndpointTests(TestCase):
 
     def test_api_should_not_fail_when_try_to_set_any_object_as_gazettes_interface(self):
         configure_api_app(
-            MockGazetteAccessInterface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
+            gazettes=MockGazetteAccessInterface(),
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
 
     def test_gazettes_endpoint_should_accept_territory_id_in_the_path(self):
-        interface = self.create_mock_gazette_interface()
+        interface = self.create_mock_gazette_interface() 
+
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+
         client = TestClient(app)
-        response = client.get("/gazettes/4205902")
+        response = client.get("/gazettes?territory_ids=4205902")
+
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            "4205902", interface.get_gazettes.call_args.args[0].territory_id
+            "4205902", interface.get_gazettes.call_args.args[0].territory_ids[0]
         )
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].since)
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].until)
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].querystring)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].published_since)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].published_until)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].scraped_since)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].scraped_until)
+        self.assertIsNotNone(interface.get_gazettes.call_args.args[0].querystring)
         self.assertIsNotNone(interface.get_gazettes.call_args.args[0].offset)
         self.assertIsNotNone(interface.get_gazettes.call_args.args[0].size)
 
-    def test_gazettes_endpoint_should_accept_query_since_date(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+    def test_gazettes_endpoint_should_accept_query_published_since_date(self):
+        client = self.get_test_client()
+
         response = client.get(
-            "/gazettes/4205902", params={"since": date.today().strftime("%Y-%m-%d")}
+            "/gazettes?territory_ids=4205902", params={"published_since": date.today().strftime("%Y-%m-%d")}
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_gazettes_endpoint_should_accept_query_published_until_date(self):
+        client = self.get_test_client()
+
+        response = client.get(
+            "/gazettes?territory_ids=4205902", params={"published_until": date.today().strftime("%Y-%m-%d")}
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_gazettes_endpoint_should_accept_query_until_date(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+    def test_gazettes_endpoint_should_accept_query_scraped_since_date(self):
+        client = self.get_test_client()
+
         response = client.get(
-            "/gazettes/4205902", params={"until": date.today().strftime("%Y-%m-%d")}
+            "/gazettes?territory_ids=4205902", params={"scraped_since": datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_gazettes_endpoint_should_fail_with_invalid_since_value(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
+    def test_gazettes_endpoint_should_accept_query_scraped_until_date(self):
+        client = self.get_test_client()
+
+        response = client.get(
+            "/gazettes?territory_ids=4205902", params={"scraped_until": datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}
         )
-        client = TestClient(app)
-        response = client.get("/gazettes/4205902", params={"since": "foo-bar-2222"})
+        self.assertEqual(response.status_code, 200)
+
+    def test_gazettes_endpoint_should_fail_with_invalid_published_since_value(self):
+        client = self.get_test_client()
+
+        response = client.get("/gazettes?territory_ids=4205902", params={"published_since": "foo-bar-2222"})
         self.assertEqual(response.status_code, 422)
 
-    def test_gazettes_endpoint_should_fail_with_invalid_until_value(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
-        response = client.get("/gazettes/4205902", params={"until": "foo-bar-2222"})
+    def test_gazettes_endpoint_should_fail_with_invalid_published_until_value(self):
+        
+        client = self.get_test_client()
+
+        response = client.get("/gazettes?territory_ids=4205902", params={"published_until": "foo-bar-2222"})
+
+        self.assertEqual(response.status_code, 422)
+
+    def test_gazettes_endpoint_should_fail_with_invalid_scraped_since_value(self):
+        
+        client = self.get_test_client()
+
+        response = client.get("/gazettes?territory_ids=4205902", params={"scraped_until": "foo-bar-2222"})
+
+        self.assertEqual(response.status_code, 422)
+    
+    def test_gazettes_endpoint_should_fail_with_invalid_scraped_until_value(self):
+        
+        client = self.get_test_client()
+
+        response = client.get("/gazettes?territory_ids=4205902", params={"scraped_until": "foo-bar-2222"})
+
         self.assertEqual(response.status_code, 422)
 
     def test_gazettes_endpoint_should_fail_with_invalid_pagination_data(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+        client = self.get_test_client()
+
         response = client.get(
-            "/gazettes/4205902", params={"offset": "asfasdasd", "size": "10"}
+            "/gazettes?territory_ids=4205902", params={"offset": "asfasdasd", "size": "10"}
         )
+
         self.assertEqual(response.status_code, 422)
+
         response = client.get(
-            "/gazettes/4205902", params={"offset": "10", "size": "ssddsfds"}
+            "/gazettes?territory_ids=4205902", params={"offset": "10", "size": "ssddsfds"}
         )
+
         self.assertEqual(response.status_code, 422)
+
         response = client.get(
-            "/gazettes/4205902", params={"offset": "x", "size": "asdasdas"}
+            "/gazettes?territory_ids=4205902", params={"offset": "x", "size": "asdasdas"}
         )
+
         self.assertEqual(response.status_code, 422)
 
     def test_get_gazettes_without_territory_id_should_be_fine(self):
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+        
         client = TestClient(app)
-        response = client.get("/gazettes/")
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].territory_id)
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].since)
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].until)
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].querystring)
+        response = client.get("/gazettes")
+        
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].published_since)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].published_until)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].scraped_since)
+        self.assertIsNone(interface.get_gazettes.call_args.args[0].scraped_until)
+        self.assertIsNotNone(interface.get_gazettes.call_args.args[0].querystring)
         self.assertIsNotNone(interface.get_gazettes.call_args.args[0].offset)
         self.assertIsNotNone(interface.get_gazettes.call_args.args[0].size)
 
     def test_get_gazettes_should_request_gazettes_to_interface_object(self):
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+        
         client = TestClient(app)
-        response = client.get("/gazettes/4205902")
+
+        response = client.get("/gazettes?territory_ids=4205902")
+        
         self.assertEqual(response.status_code, 200)
+
         interface.get_gazettes.assert_called_once()
 
     def test_get_gazettes_should_forward_gazettes_filters_to_interface_object(self):
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+
         client = TestClient(app)
+
+        today = date.today().strftime("%Y-%m-%d")
+        datetime_now   = datetime.now().replace(microsecond=0).isoformat()
+
+
         response = client.get(
-            "/gazettes/4205902",
+            "/gazettes?territory_ids=4205902",
             params={
-                "since": date.today().strftime("%Y-%m-%d"),
-                "until": date.today().strftime("%Y-%m-%d"),
+                "published_since": today,
+                "published_until": today,
+                "scraped_since": datetime_now,
+                "scraped_until": datetime_now,
                 "offset": 10,
                 "size": 100,
             },
         )
+
         self.assertEqual(response.status_code, 200)
         interface.get_gazettes.assert_called_once()
         self.assertEqual(
-            interface.get_gazettes.call_args.args[0].territory_id, "4205902"
+            interface.get_gazettes.call_args.args[0].territory_ids[0], "4205902"
         )
-        self.assertEqual(
-            interface.get_gazettes.call_args.args[0].since, date.today(),
-        )
-        self.assertEqual(interface.get_gazettes.call_args.args[0].until, date.today())
+        self.assertEqual(interface.get_gazettes.call_args.args[0].published_since, date.today())
+        self.assertEqual(interface.get_gazettes.call_args.args[0].published_until, date.today())
+        self.assertEqual(interface.get_gazettes.call_args.args[0].scraped_since, datetime.now().replace(microsecond=0))
+        self.assertEqual(interface.get_gazettes.call_args.args[0].scraped_until, datetime.now().replace(microsecond=0))
         self.assertEqual(interface.get_gazettes.call_args.args[0].offset, 10)
         self.assertEqual(interface.get_gazettes.call_args.args[0].size, 100)
 
+
     def test_get_gazettes_should_return_json_with_items(self):
         today = date.today()
+
+        formatted_datetime_now = datetime.now().isoformat()
+        
         interface = self.create_mock_gazette_interface(
             (
                 1,
@@ -190,25 +294,37 @@ class ApiGazettesEndpointTests(TestCase):
                     {
                         "territory_id": "4205902",
                         "date": today,
+                        "scraped_at": formatted_datetime_now,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "excerpts": [],
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     }
                 ],
             )
         )
+
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+        
         client = TestClient(app)
-        response = client.get("/gazettes/4205902")
+        
+        response = client.get("/gazettes?territory_ids=4205902")
         interface.get_gazettes.assert_called_once()
+        
         self.assertEqual(
-            interface.get_gazettes.call_args.args[0].territory_id, "4205902"
+            interface.get_gazettes.call_args.args[0].territory_ids[0], "4205902"
         )
+        
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.json(),
@@ -218,28 +334,40 @@ class ApiGazettesEndpointTests(TestCase):
                     {
                         "territory_id": "4205902",
                         "date": today.strftime("%Y-%m-%d"),
+                        "scraped_at": formatted_datetime_now, 
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
-                        "state_code": "My state",
+                        "state_code": "My state", 
+                        "excerpts": [],
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     }
                 ],
             },
         )
 
     def test_get_gazettes_should_return_empty_list_when_no_gazettes_is_found(self):
-        today = date.today()
+        
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
-        client = TestClient(app)
-        response = client.get("/gazettes/4205902")
+        
+        client   = TestClient(app)
+        
+        response = client.get("/gazettes?territory_ids=4205902")
+        
         interface.get_gazettes.assert_called_once()
+        
         self.assertEqual(
-            interface.get_gazettes.call_args.args[0].territory_id, "4205902"
+            interface.get_gazettes.call_args.args[0].territory_ids[0], "4205902"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -247,132 +375,190 @@ class ApiGazettesEndpointTests(TestCase):
         )
 
     def test_gazettes_endpoint_should_accept_query_querystring_date(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+        client = self.get_test_client()
+
         response = client.get(
-            "/gazettes/4205902", params={"querystring": "keyword1 keyword2"}
+            "/gazettes?territory_ids=4205902", params={"querystring": "keyword1 keyword2"}
         )
         self.assertEqual(response.status_code, 200)
-        response = client.get("/gazettes/4205902", params={"querystring": []})
+        response = client.get("/gazettes?territory_ids=4205902", params={"querystring": []})
         self.assertEqual(response.status_code, 200)
 
-    def test_get_gazettes_should_forward_querystring_to_interface_object(self):
+    def test_get_gazettes_should_forward_querystring_to_interface_object(self): #TODO: separar os testes
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+        
         client = TestClient(app)
 
         response = client.get(
-            "/gazettes/4205902", params={"querystring": "keyword1 1 True"}
+            "/gazettes?terriotry_ids=4205902", params={"querystring": "keyword1 1 True"}
         )
+
         interface.get_gazettes.assert_called_once()
+
         self.assertEqual(
             interface.get_gazettes.call_args.args[0].querystring, "keyword1 1 True"
         )
+        
+        # --------------------------------------------------
 
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
-        response = client.get("/gazettes/4205902", params={"querystring": None})
+        
+        response = client.get("/gazettes?territory_ids=4205902", params={"querystring": None})
         interface.get_gazettes.assert_called_once()
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].querystring)
+        
+        self.assertIsNotNone(interface.get_gazettes.call_args.args[0].querystring)
+        
+        # ----------------------------------------------------
 
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
-        response = client.get("/gazettes/4205902", params={"querystring": ""})
+
+        response = client.get("/gazettes?territory_ids=4205902", params={"querystring": ""})
         interface.get_gazettes.assert_called_once()
+        
         self.assertEqual(interface.get_gazettes.call_args.args[0].querystring, "")
 
-    def test_gazettes_without_territory_endpoint__should_accept_query_since_date(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+    def test_gazettes_without_territory_ids_endpoint_should_accept_query_published_since_date(self):
+        client = self.get_test_client()
+        
         response = client.get(
-            "/gazettes", params={"since": date.today().strftime("%Y-%m-%d")}
+            "/gazettes", params={"published_since": date.today().strftime("%Y-%m-%d")}
         )
         self.assertEqual(response.status_code, 200)
 
-    def test_gazettes_without_territory_endpoint__should_accept_query_until_date(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+    def test_gazettes_without_territory_ids_endpoint_should_accept_query_published_until_date(self):
+        client = self.get_test_client()
+        
         response = client.get(
-            "/gazettes", params={"until": date.today().strftime("%Y-%m-%d")}
+            "/gazettes", params={"published_until": date.today().strftime("%Y-%m-%d")}
         )
+        
         self.assertEqual(response.status_code, 200)
 
-    def test_gazettes_without_territory_endpoint__should_fail_with_invalid_since_value(
-        self,
-    ):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
+    def test_gazettes_without_territory_ids_endpoint_should_accept_query_scraped_since_date(self):
+        client = self.get_test_client()
+        
+        response = client.get(
+            "/gazettes", params={"scraped_since":  datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}
         )
-        client = TestClient(app)
-        response = client.get("/gazettes", params={"since": "foo-bar-2222"})
+        
+        self.assertEqual(response.status_code, 200)
+
+    def test_gazettes_without_territory_ids_endpoint_should_accept_query_scraped_until_date(self):
+        client = self.get_test_client()
+        
+        response = client.get(
+            "/gazettes", params={"scraped_until": datetime.now().strftime("%Y-%m-%dT%H:%M:%S")}
+        )
+        
+        self.assertEqual(response.status_code, 200)
+
+    def test_gazettes_without_territory_ids_endpoint_should_fail_with_invalid_published_since_value(self):
+        client = self.get_test_client()
+
+        response = client.get("/gazettes", params={"published_since": "foo-bar-2222"})
+        
         self.assertEqual(response.status_code, 422)
 
-    def test_gazettes_without_territory_endpoint__should_fail_with_invalid_until_value(
-        self,
-    ):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
-        response = client.get("/gazettes", params={"until": "foo-bar-2222"})
+    def test_gazettes_without_territory_ids_endpoint_should_fail_with_invalid_published_until_value(self):
+        client = self.get_test_client()
+
+        response = client.get("/gazettes", params={"published_until": "foo-bar-2222"})
+        
+        self.assertEqual(response.status_code, 422)
+    
+    def test_gazettes_without_territory_ids_endpoint_should_fail_with_invalid_scraped_since_value(self):
+        client = self.get_test_client()
+
+        response = client.get("/gazettes", params={"scraped_since": "foo-bar-2222"})
+        
         self.assertEqual(response.status_code, 422)
 
-    def test_get_gazettes_without_territory_id_should_forward_gazettes_filters_to_interface_object(
-        self,
-    ):
+    def test_gazettes_without_territory_ids_endpoint_should_fail_with_invalid_scraped_until_value(self):
+        client = self.get_test_client()
+
+        response = client.get("/gazettes", params={"scraped_until": "foo-bar-2222"})
+        
+        self.assertEqual(response.status_code, 422)    
+
+    def test_get_gazettes_without_territory_id_should_forward_gazettes_filters_to_interface_object(self):
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+        
         client = TestClient(app)
+        
         response = client.get(
             "/gazettes",
             params={
-                "since": date.today().strftime("%Y-%m-%d"),
-                "until": date.today().strftime("%Y-%m-%d"),
+                "published_since": date.today().strftime("%Y-%m-%d"),
+                "published_until": date.today().strftime("%Y-%m-%d"),
+                "scraped_since": datetime.now().replace(microsecond=0).isoformat(),
+                "scraped_until": datetime.now().replace(microsecond=0).isoformat(),
                 "offset": 10,
                 "size": 100,
             },
         )
+        
         self.assertEqual(response.status_code, 200)
         interface.get_gazettes.assert_called_once()
-        self.assertIsNone(interface.get_gazettes.call_args.args[0].territory_id)
-        self.assertEqual(
-            interface.get_gazettes.call_args.args[0].since, date.today(),
-        )
-        self.assertEqual(interface.get_gazettes.call_args.args[0].until, date.today())
+        self.assertEqual(interface.get_gazettes.call_args.args[0].territory_ids, [])
+        self.assertEqual(interface.get_gazettes.call_args.args[0].published_since, date.today())
+        self.assertEqual(interface.get_gazettes.call_args.args[0].published_until, date.today())
+        self.assertEqual(interface.get_gazettes.call_args.args[0].scraped_since, datetime.now().replace(microsecond=0))
+        self.assertEqual(interface.get_gazettes.call_args.args[0].scraped_until, datetime.now().replace(microsecond=0)) 
         self.assertEqual(interface.get_gazettes.call_args.args[0].offset, 10)
         self.assertEqual(interface.get_gazettes.call_args.args[0].size, 100)
 
     def test_api_should_forward_the_result_offset(self):
         interface = self.create_mock_gazette_interface()
+        
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(), 
         )
+
         client = TestClient(app)
-        response = client.get("/gazettes", params={"offset": 0,},)
+        
+        response = client.get("/gazettes", params={"offset": 0,})
+        
         self.assertEqual(response.status_code, 200)
         interface.get_gazettes.assert_called_once()
         self.assertEqual(interface.get_gazettes.call_args.args[0].offset, 0)
@@ -380,24 +566,35 @@ class ApiGazettesEndpointTests(TestCase):
     @expectedFailure
     def test_configure_api_should_failed_with_invalid_root_path(self):
         configure_api_app(
-            MockGazetteAccessInterface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
+            gazettes=MockGazetteAccessInterface(),
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(),
             api_root_path=1,
         )
 
     def test_configure_api_root_path(self):
         configure_api_app(
-            MockGazetteAccessInterface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
+            gazettes=MockGazetteAccessInterface(),
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(),
             api_root_path="/api/v1",
         )
+
         self.assertEqual("/api/v1", app.root_path)
 
     def test_api_without_edition_and_extra_field(self):
         today = date.today()
         yesterday = today - timedelta(days=1)
+
+        scraped_at = datetime.now().isoformat()
+        yesterday_scraped_at = (datetime.now() - timedelta(days=1)).isoformat()
+
         interface = self.create_mock_gazette_interface(
             (
                 2,
@@ -405,32 +602,49 @@ class ApiGazettesEndpointTests(TestCase):
                     {
                         "territory_id": "4205902",
                         "date": today,
+                        "scraped_at": scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "excerpts": [],
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     },
                     {
                         "territory_id": "4205902",
                         "date": yesterday,
+                        "scraped_at": yesterday_scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
-                        "highlight_texts": ["test"],
+                        "excerpts": [],
+                        "is_extra_edition": False,
+                        "edition": "12.3442",
+                        "txt_url": "https://queridodiario.ok.org.br/"
                     },
                 ],
             )
         )
+
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(),
+            api_root_path="/api/v1",
         )
+
         client = TestClient(app)
-        response = client.get("/gazettes/4205902")
+        
+        response = client.get("/gazettes?territory_ids=4205902")
+        
         interface.get_gazettes.assert_called_once()
+        
         self.assertEqual(
-            interface.get_gazettes.call_args.args[0].territory_id, "4205902"
+            interface.get_gazettes.call_args.args[0].territory_ids[0], "4205902"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -440,21 +654,27 @@ class ApiGazettesEndpointTests(TestCase):
                 "gazettes": [
                     {
                         "territory_id": "4205902",
-                        "date": today.strftime("%Y-%m-%d"),
+                        "date": today,
+                        "scraped_at": scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "excerpts": [],
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     },
                     {
                         "territory_id": "4205902",
                         "date": yesterday.strftime("%Y-%m-%d"),
+                        "scraped_at": yesterday_scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
-                        "highlight_texts": ["test"],
+                        "excerpts": [],
+                        "is_extra_edition": False,
+                        "edition": "12.3442",
+                        "txt_url": "https://queridodiario.ok.org.br/"
                     },
                 ],
             },
@@ -463,6 +683,10 @@ class ApiGazettesEndpointTests(TestCase):
     def test_api_with_none_edition_and_extra_field(self):
         today = date.today()
         yesterday = today - timedelta(days=1)
+
+        scraped_at = datetime.now().isoformat()
+        yesterday_scraped_at = (datetime.now() - timedelta(days=1)).isoformat()
+
         interface = self.create_mock_gazette_interface(
             (
                 2,
@@ -470,36 +694,51 @@ class ApiGazettesEndpointTests(TestCase):
                     {
                         "territory_id": "4205902",
                         "date": today,
+                        "scraped_at": scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "excerpts": [],
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     },
                     {
                         "territory_id": "4205902",
                         "date": yesterday,
+                        "scraped_at": yesterday_scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "excerpts": [],
                         "is_extra_edition": None,
                         "edition": None,
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     },
                 ],
             )
         )
+
         configure_api_app(
-            interface, MockSuggestionService(), MockCompaniesAccessInterface()
+            gazettes=interface,
+            themed_excerpts=MockThemedExcerptAccessInterface(),
+            cities=MockCityAccessInterface(),
+            suggestion_service=MockSuggestionService(),
+            companies=MockCompaniesAccessInterface(),
+            aggregates=MockAggregatesAccessInterface(),
         )
+
         client = TestClient(app)
-        response = client.get("/gazettes/4205902")
+        
+        response = client.get("/gazettes?territory_ids=4205902")
         interface.get_gazettes.assert_called_once()
+        
         self.assertEqual(
-            interface.get_gazettes.call_args.args[0].territory_id, "4205902"
+            interface.get_gazettes.call_args.args[0].territory_ids[0], "4205902"
         )
-        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.status_code, 200)   
+
         self.assertEqual(
             response.json(),
             {
@@ -508,33 +747,34 @@ class ApiGazettesEndpointTests(TestCase):
                     {
                         "territory_id": "4205902",
                         "date": today.strftime("%Y-%m-%d"),
+                        "scraped_at": scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
+                        "excerpts": [],
                         "is_extra_edition": False,
                         "edition": "12.3442",
-                        "highlight_texts": ["test"],
+                        "txt_url": "https://queridodiario.ok.org.br/",
                     },
                     {
                         "territory_id": "4205902",
                         "date": yesterday.strftime("%Y-%m-%d"),
+                        "scraped_at": yesterday_scraped_at,
                         "url": "https://queridodiario.ok.org.br/",
                         "territory_name": "My city",
                         "state_code": "My state",
-                        "highlight_texts": ["test"],
+                        "excerpts": [],
+                        "txt_url": "https://queridodiario.ok.org.br/"
                     },
                 ],
             },
         )
 
     def test_cities_endpoint_should_reject_request_without_partial_city_name(self):
-        configure_api_app(
-            self.create_mock_gazette_interface(),
-            MockSuggestionService(),
-            MockCompaniesAccessInterface(),
-        )
-        client = TestClient(app)
+        client = self.get_test_client()
+        
         response = client.get("/cities")
+
         self.assertNotEqual(response.status_code, 200)
 
     def test_cities_endpoint_should_accept_request_without_partial_city_name(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,36 +12,263 @@ class BasicConfigurationTests(TestCase):
             expected_values["QUERIDO_DIARIO_OPENSEARCH_HOST"],
             msg="Invalid opensearch host",
         )
-        self.assertEqual(
-            configuration.index,
-            expected_values["QUERIDO_DIARIO_OPENSEARCH_INDEX"],
-            msg="Invalid opensearch index",
-        )
+
         self.assertEqual(
             configuration.root_path,
             expected_values["QUERIDO_DIARIO_API_ROOT_PATH"],
             msg="Invalid API root path",
         )
+
         self.assertEqual(
             configuration.url_prefix,
             expected_values["QUERIDO_DIARIO_URL_PREFIX"],
             msg="Invalid URL prefix",
         )
+
         self.assertEqual(
             configuration.cors_allow_origins,
             expected_values["QUERIDO_DIARIO_CORS_ALLOW_ORIGINS"],
+            msg="Invalid CORS allow origins",
         )
+
         self.assertEqual(
             configuration.cors_allow_credentials,
             expected_values["QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS"],
+            msg="Invalid CORS allow credentials",
         )
+
         self.assertEqual(
             configuration.cors_allow_methods,
             expected_values["QUERIDO_DIARIO_CORS_ALLOW_METHODS"],
+            msg="Invalid CORS allow methods",
         )
+
         self.assertEqual(
             configuration.cors_allow_headers,
             expected_values["QUERIDO_DIARIO_CORS_ALLOW_HEADERS"],
+            msg="Invalid CORS allow headers",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_mailjet_rest_api_key,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_KEY"],
+            msg="Invalid suggestion mailjet rest API key",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_mailjet_rest_api_secret,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_SECRET"],
+            msg="Invalid suggestion mailjet rest API secret",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_sender_name,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_SENDER_NAME"],
+            msg="Invalid suggestion sender name",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_sender_email,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_SENDER_EMAIL"],
+            msg="Invalid suggestion sender Email",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_recipient_name,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_RECIPIENT_NAME"],
+            msg="Invalid suggestion recipient name",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_recipient_email,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_RECIPIENT_EMAIL"],
+            msg="Invalid suggestion recipient Email",
+        )
+
+        self.assertEqual(
+            configuration.suggestion_mailjet_custom_id,
+            expected_values["QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID"],
+            msg="Invalid suggestion mailjet custom ID",
+        )
+
+        self.assertEqual(
+            configuration.city_database_file,
+            expected_values["CITY_DATABASE_CSV"],
+            msg="Invalid city database csv",
+        )
+
+        self.assertEqual(
+            configuration.gazette_index,
+            expected_values["GAZETTE_OPENSEARCH_INDEX"],
+            msg="Invalid gazette index",
+        )
+
+        self.assertEqual(
+            configuration.gazette_content_field,
+            expected_values["GAZETTE_CONTENT_FIELD"],
+            msg="Invalid gazette content field",
+        )
+
+        self.assertEqual(
+            configuration.gazette_content_exact_field_suffix,
+            expected_values["GAZETTE_CONTENT_EXACT_FIELD_SUFFIX"],
+            msg="Invalid gazette content exact field suffix",
+        )
+
+        self.assertEqual(
+            configuration.gazette_publication_date_field,
+            expected_values["GAZETTE_PUBLICATION_DATE_FIELD"],
+            msg="Invalid gazette publication date field",
+        )
+
+        self.assertEqual(
+            configuration.gazette_scraped_at_field,
+            expected_values["GAZETTE_SCRAPED_AT_FIELD"],
+            msg="Invalid gazette scraped at field",
+        )
+
+        self.assertEqual(
+            configuration.gazette_territory_id_field,
+            expected_values["GAZETTE_TERRITORY_ID_FIELD"],
+            msg="Invalid gazette territory ID field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_content_field,
+            expected_values["THEMED_EXCERPT_CONTENT_FIELD"],
+            msg="Invalid themed excerpt content field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_content_exact_field_suffix,
+            expected_values["THEMED_EXCERPT_CONTENT_EXACT_FIELD_SUFFIX"],
+            msg="Invalid themed excerpt content exact field suffix",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_publication_date_field,
+            expected_values["THEMED_EXCERPT_PUBLICATION_DATE_FIELD"],
+            msg="Invalid themed excerpt publication date field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_scraped_at_field,
+            expected_values["THEMED_EXCERPT_SCRAPED_AT_FIELD"],
+            msg="Invalid themed excerpt scraped at field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_territory_id_field,
+            expected_values["THEMED_EXCERPT_TERRITORY_ID_FIELD"],
+            msg="Invalid themed excerpt territory ID field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_entities_field,
+            expected_values["THEMED_EXCERPT_ENTITIES_FIELD"],
+            msg="Invalid themed excerpt entities field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_subthemes_field,
+            expected_values["THEMED_EXCERPT_SUBTHEMES_FIELD"],
+            msg="Invalid themed excerpt subthemes field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_embedding_score_field,
+            expected_values["THEMED_EXCERPT_EMBEDDING_SCORE_FIELD"],
+            msg="Invalid themed excerpt embedding score field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_tfidf_score_field,
+            expected_values["THEMED_EXCERPT_TFIDF_SCORE_FIELD"],
+            msg="Invalid themed excerpt TF-IDF score field",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_fragment_size,
+            expected_values["THEMED_EXCERPT_FRAGMENT_SIZE"],
+            msg="Invalid themed excerpt fragment size",
+        )
+
+        self.assertEqual(
+            configuration.themed_excerpt_number_of_fragments,
+            expected_values["THEMED_EXCERPT_NUMBER_OF_FRAGMENTS"],
+            msg="Invalid themed excerpt number of fragments",
+        )
+
+        self.assertEqual(
+            configuration.companies_database_host,
+            expected_values["POSTGRES_COMPANIES_HOST"],
+            msg="Invalid Postgres companies host",
+        )
+
+        self.assertEqual(
+            configuration.companies_database_db,
+            expected_values["POSTGRES_COMPANIES_DB"],
+            msg="Invalid Postgres companies database",
+        )
+
+        self.assertEqual(
+            configuration.companies_database_user,
+            expected_values["POSTGRES_COMPANIES_USER"],
+            msg="Invalid Postgres companies user",
+        )
+
+        self.assertEqual(
+            configuration.companies_database_pass,
+            expected_values["POSTGRES_COMPANIES_PASSWORD"],
+            msg="Invalid Postgres companies password",
+        )
+
+        self.assertEqual(
+            configuration.companies_database_port,
+            expected_values["POSTGRES_COMPANIES_PORT"],
+            msg="Invalid Postgres companies port",
+        )
+
+        self.assertEqual(
+            configuration.opensearch_user,
+            expected_values["QUERIDO_DIARIO_OPENSEARCH_USER"],
+            msg="Invalid OpenSearch user",
+        )
+
+        self.assertEqual(
+            configuration.opensearch_pswd,
+            expected_values["QUERIDO_DIARIO_OPENSEARCH_PASSWORD"],
+            msg="Invalid OpenSearch password",
+        )
+
+        self.assertEqual(
+            configuration.aggregates_database_host,
+            expected_values["POSTGRES_AGGREGATES_HOST"],
+            msg="Invalid Postgres aggregates host",
+        )
+
+        self.assertEqual(
+            configuration.aggregates_database_db,
+            expected_values["POSTGRES_AGGREGATES_DB"],
+            msg="Invalid Postgres aggregates database",
+        )
+
+        self.assertEqual(
+            configuration.aggregates_database_user,
+            expected_values["POSTGRES_AGGREGATES_USER"],
+            msg="Invalid Postgres aggregates user",
+        )
+
+        self.assertEqual(
+            configuration.aggregates_database_pass,
+            expected_values["POSTGRES_AGGREGATES_PASSWORD"],
+            msg="Invalid Postgres aggregates password",
+        )
+
+        self.assertEqual(
+            configuration.aggregates_database_port,
+            expected_values["POSTGRES_AGGREGATES_PORT"],
+            msg="Invalid Postgres aggregates port",
         )
 
     @patch.dict(
@@ -50,14 +277,52 @@ class BasicConfigurationTests(TestCase):
     def test_load_configuration_with_no_envvars(self):
         expected_config_dict = {
             "QUERIDO_DIARIO_OPENSEARCH_HOST": "",
-            "QUERIDO_DIARIO_OPENSEARCH_INDEX": "",
             "QUERIDO_DIARIO_API_ROOT_PATH": "",
             "QUERIDO_DIARIO_URL_PREFIX": "",
             "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": ["*"],
             "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": True,
             "QUERIDO_DIARIO_CORS_ALLOW_METHODS": ["*"],
             "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": ["*"],
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_KEY": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_SECRET": "",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_NAME": "",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_EMAIL": "",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_NAME": "",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_EMAIL": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID": "",
+            "CITY_DATABASE_CSV": "",
+            "GAZETTE_OPENSEARCH_INDEX": "",
+            "GAZETTE_CONTENT_FIELD": "",
+            "GAZETTE_CONTENT_EXACT_FIELD_SUFFIX": "",
+            "GAZETTE_PUBLICATION_DATE_FIELD": "",
+            "GAZETTE_SCRAPED_AT_FIELD": "",
+            "GAZETTE_TERRITORY_ID_FIELD": "",
+            "THEMES_DATABASE_JSON": "",
+            "THEMED_EXCERPT_CONTENT_FIELD": "",
+            "THEMED_EXCERPT_CONTENT_EXACT_FIELD_SUFFIX": "",
+            "THEMED_EXCERPT_PUBLICATION_DATE_FIELD": "",
+            "THEMED_EXCERPT_SCRAPED_AT_FIELD": "",
+            "THEMED_EXCERPT_TERRITORY_ID_FIELD": "",
+            "THEMED_EXCERPT_ENTITIES_FIELD": "",
+            "THEMED_EXCERPT_SUBTHEMES_FIELD": "",
+            "THEMED_EXCERPT_EMBEDDING_SCORE_FIELD": "",
+            "THEMED_EXCERPT_TFIDF_SCORE_FIELD": "",
+            "THEMED_EXCERPT_FRAGMENT_SIZE": 10000,
+            "THEMED_EXCERPT_NUMBER_OF_FRAGMENTS": 1,
+            "POSTGRES_COMPANIES_HOST": "",
+            "POSTGRES_COMPANIES_DB": "",
+            "POSTGRES_COMPANIES_USER": "",
+            "POSTGRES_COMPANIES_PASSWORD": "",
+            "POSTGRES_COMPANIES_PORT": "",
+            "QUERIDO_DIARIO_OPENSEARCH_USER": "",
+            "QUERIDO_DIARIO_OPENSEARCH_PASSWORD": "",
+            "POSTGRES_AGGREGATES_HOST": "",
+            "POSTGRES_AGGREGATES_DB": "",
+            "POSTGRES_AGGREGATES_USER": "",
+            "POSTGRES_AGGREGATES_PASSWORD": "",
+            "POSTGRES_AGGREGATES_PORT": "",
         }
+
         configuration = load_configuration()
         self.check_configuration_values(configuration, expected_config_dict)
 
@@ -65,26 +330,100 @@ class BasicConfigurationTests(TestCase):
         "os.environ",
         {
             "QUERIDO_DIARIO_OPENSEARCH_HOST": "",
-            "QUERIDO_DIARIO_OPENSEARCH_INDEX": "",
             "QUERIDO_DIARIO_API_ROOT_PATH": "",
             "QUERIDO_DIARIO_URL_PREFIX": "",
             "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": "",
             "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": "",
             "QUERIDO_DIARIO_CORS_ALLOW_METHODS": "",
             "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_KEY": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_SECRET": "",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_NAME": "",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_EMAIL": "",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_NAME": "",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_EMAIL": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID": "",
+            "CITY_DATABASE_CSV": "",
+            "GAZETTE_OPENSEARCH_INDEX": "",
+            "GAZETTE_CONTENT_FIELD": "",
+            "GAZETTE_CONTENT_EXACT_FIELD_SUFFIX": "",
+            "GAZETTE_PUBLICATION_DATE_FIELD": "",
+            "GAZETTE_SCRAPED_AT_FIELD": "",
+            "GAZETTE_TERRITORY_ID_FIELD": "",
+            "THEMES_DATABASE_JSON": "",
+            "THEMED_EXCERPT_CONTENT_FIELD": "",
+            "THEMED_EXCERPT_CONTENT_EXACT_FIELD_SUFFIX": "",
+            "THEMED_EXCERPT_PUBLICATION_DATE_FIELD": "",
+            "THEMED_EXCERPT_SCRAPED_AT_FIELD": "",
+            "THEMED_EXCERPT_TERRITORY_ID_FIELD": "",
+            "THEMED_EXCERPT_ENTITIES_FIELD": "",
+            "THEMED_EXCERPT_SUBTHEMES_FIELD": "",
+            "THEMED_EXCERPT_EMBEDDING_SCORE_FIELD": "",
+            "THEMED_EXCERPT_TFIDF_SCORE_FIELD": "",
+            "THEMED_EXCERPT_FRAGMENT_SIZE": "",
+            "THEMED_EXCERPT_NUMBER_OF_FRAGMENTS": "",
+            "POSTGRES_COMPANIES_HOST": "",
+            "POSTGRES_COMPANIES_DB": "",
+            "POSTGRES_COMPANIES_USER": "",
+            "POSTGRES_COMPANIES_PASSWORD": "",
+            "POSTGRES_COMPANIES_PORT": "",
+            "QUERIDO_DIARIO_OPENSEARCH_USER": "",
+            "QUERIDO_DIARIO_OPENSEARCH_PASSWORD": "",
+            "POSTGRES_AGGREGATES_HOST": "",
+            "POSTGRES_AGGREGATES_DB": "",
+            "POSTGRES_AGGREGATES_USER": "",
+            "POSTGRES_AGGREGATES_PASSWORD": "",
+            "POSTGRES_AGGREGATES_PORT": "",
         },
         True,
     )
     def test_load_configuration_with_empty_envvars(self):
         expected_config_dict = {
             "QUERIDO_DIARIO_OPENSEARCH_HOST": "",
-            "QUERIDO_DIARIO_OPENSEARCH_INDEX": "",
             "QUERIDO_DIARIO_API_ROOT_PATH": "",
             "QUERIDO_DIARIO_URL_PREFIX": "",
             "QUERIDO_DIARIO_CORS_ALLOW_ORIGINS": [""],
             "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": True,
             "QUERIDO_DIARIO_CORS_ALLOW_METHODS": [""],
             "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": [""],
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_KEY": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_SECRET": "",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_NAME": "",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_EMAIL": "",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_NAME": "",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_EMAIL": "",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID": "",
+            "CITY_DATABASE_CSV": "",
+            "GAZETTE_OPENSEARCH_INDEX": "",
+            "GAZETTE_CONTENT_FIELD": "",
+            "GAZETTE_CONTENT_EXACT_FIELD_SUFFIX": "",
+            "GAZETTE_PUBLICATION_DATE_FIELD": "",
+            "GAZETTE_SCRAPED_AT_FIELD": "",
+            "GAZETTE_TERRITORY_ID_FIELD": "",
+            "THEMES_DATABASE_JSON": "",
+            "THEMED_EXCERPT_CONTENT_FIELD": "",
+            "THEMED_EXCERPT_CONTENT_EXACT_FIELD_SUFFIX": "",
+            "THEMED_EXCERPT_PUBLICATION_DATE_FIELD": "",
+            "THEMED_EXCERPT_SCRAPED_AT_FIELD": "",
+            "THEMED_EXCERPT_TERRITORY_ID_FIELD": "",
+            "THEMED_EXCERPT_ENTITIES_FIELD": "",
+            "THEMED_EXCERPT_SUBTHEMES_FIELD": "",
+            "THEMED_EXCERPT_EMBEDDING_SCORE_FIELD": "",
+            "THEMED_EXCERPT_TFIDF_SCORE_FIELD": "",
+            "THEMED_EXCERPT_FRAGMENT_SIZE": 10000,
+            "THEMED_EXCERPT_NUMBER_OF_FRAGMENTS": 1,
+            "POSTGRES_COMPANIES_HOST": "",
+            "POSTGRES_COMPANIES_DB": "",
+            "POSTGRES_COMPANIES_USER": "",
+            "POSTGRES_COMPANIES_PASSWORD": "",
+            "POSTGRES_COMPANIES_PORT": "",
+            "QUERIDO_DIARIO_OPENSEARCH_USER": "",
+            "QUERIDO_DIARIO_OPENSEARCH_PASSWORD": "",
+            "POSTGRES_AGGREGATES_HOST": "",
+            "POSTGRES_AGGREGATES_DB": "",
+            "POSTGRES_AGGREGATES_USER": "",
+            "POSTGRES_AGGREGATES_PASSWORD": "",
+            "POSTGRES_AGGREGATES_PORT": "",
         }
         configuration = load_configuration()
         self.check_configuration_values(configuration, expected_config_dict)
@@ -92,7 +431,7 @@ class BasicConfigurationTests(TestCase):
     @patch.dict(
         "os.environ",
         {
-            "QUERIDO_DIARIO_OPENSEARCH_HOST": "000.0.0.0",
+            "QUERIDO_DIARIO_OPENSEARCH_HOST": "0.0.0.0",
             "QUERIDO_DIARIO_OPENSEARCH_INDEX": "myindex",
             "QUERIDO_DIARIO_API_ROOT_PATH": "api/",
             "QUERIDO_DIARIO_URL_PREFIX": "https://test.com",
@@ -100,12 +439,50 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": "True",
             "QUERIDO_DIARIO_CORS_ALLOW_METHODS": "GET,POST",
             "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": "X-Test-Test",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_KEY": "dummy-api-key",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_SECRET": "dummy-api-secret",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_NAME": "Test Sender",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_EMAIL": "sender@example.com",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_NAME": "Test Recipient",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_EMAIL": "recipient@example.com",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID": "12345",
+            "CITY_DATABASE_CSV": "city_database.csv",
+            "GAZETTE_OPENSEARCH_INDEX": "gazette_index",
+            "GAZETTE_CONTENT_FIELD": "content",
+            "GAZETTE_CONTENT_EXACT_FIELD_SUFFIX": "exact",
+            "GAZETTE_PUBLICATION_DATE_FIELD": "publication_date",
+            "GAZETTE_SCRAPED_AT_FIELD": "scraped_at",
+            "GAZETTE_TERRITORY_ID_FIELD": "territory_id",
+            "THEMES_DATABASE_JSON": "/path/to/themes_database.json",
+            "THEMED_EXCERPT_CONTENT_FIELD": "excerpt_content",
+            "THEMED_EXCERPT_CONTENT_EXACT_FIELD_SUFFIX": "_exact",
+            "THEMED_EXCERPT_PUBLICATION_DATE_FIELD": "publication_date",
+            "THEMED_EXCERPT_SCRAPED_AT_FIELD": "scraped_at",
+            "THEMED_EXCERPT_TERRITORY_ID_FIELD": "territory_id",
+            "THEMED_EXCERPT_ENTITIES_FIELD": "entities",
+            "THEMED_EXCERPT_SUBTHEMES_FIELD": "subthemes",
+            "THEMED_EXCERPT_EMBEDDING_SCORE_FIELD": "embedding_score",
+            "THEMED_EXCERPT_TFIDF_SCORE_FIELD": "tfidf_score",
+            "THEMED_EXCERPT_FRAGMENT_SIZE": "1000",
+            "THEMED_EXCERPT_NUMBER_OF_FRAGMENTS": "3",
+            "POSTGRES_COMPANIES_HOST": "localhost",
+            "POSTGRES_COMPANIES_DB": "companies_test",
+            "POSTGRES_COMPANIES_USER": "test_user",
+            "POSTGRES_COMPANIES_PASSWORD": "test_password",
+            "POSTGRES_COMPANIES_PORT": "5432",
+            "QUERIDO_DIARIO_OPENSEARCH_USER": "admin",
+            "QUERIDO_DIARIO_OPENSEARCH_PASSWORD": "admin_password",
+            "POSTGRES_AGGREGATES_HOST": "localhost",
+            "POSTGRES_AGGREGATES_DB": "aggregates_test",
+            "POSTGRES_AGGREGATES_USER": "test_user",
+            "POSTGRES_AGGREGATES_PASSWORD": "test_password",
+            "POSTGRES_AGGREGATES_PORT": "5432",
         },
         True,
     )
     def test_load_configuration_with_envvars_defined(self):
         expected_config_dict = {
-            "QUERIDO_DIARIO_OPENSEARCH_HOST": "000.0.0.0",
+            "QUERIDO_DIARIO_OPENSEARCH_HOST": "0.0.0.0",
             "QUERIDO_DIARIO_OPENSEARCH_INDEX": "myindex",
             "QUERIDO_DIARIO_API_ROOT_PATH": "api/",
             "QUERIDO_DIARIO_URL_PREFIX": "https://test.com",
@@ -113,6 +490,44 @@ class BasicConfigurationTests(TestCase):
             "QUERIDO_DIARIO_CORS_ALLOW_CREDENTIALS": True,
             "QUERIDO_DIARIO_CORS_ALLOW_METHODS": ["GET", "POST"],
             "QUERIDO_DIARIO_CORS_ALLOW_HEADERS": ["X-Test-Test"],
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_KEY": "dummy-api-key",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_REST_API_SECRET": "dummy-api-secret",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_NAME": "Test Sender",
+            "QUERIDO_DIARIO_SUGGESTION_SENDER_EMAIL": "sender@example.com",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_NAME": "Test Recipient",
+            "QUERIDO_DIARIO_SUGGESTION_RECIPIENT_EMAIL": "recipient@example.com",
+            "QUERIDO_DIARIO_SUGGESTION_MAILJET_CUSTOM_ID": "12345",
+            "CITY_DATABASE_CSV": "city_database.csv",
+            "GAZETTE_OPENSEARCH_INDEX": "gazette_index",
+            "GAZETTE_CONTENT_FIELD": "content",
+            "GAZETTE_CONTENT_EXACT_FIELD_SUFFIX": "exact",
+            "GAZETTE_PUBLICATION_DATE_FIELD": "publication_date",
+            "GAZETTE_SCRAPED_AT_FIELD": "scraped_at",
+            "GAZETTE_TERRITORY_ID_FIELD": "territory_id",
+            "THEMES_DATABASE_JSON": "/path/to/themes_database.json",
+            "THEMED_EXCERPT_CONTENT_FIELD": "excerpt_content",
+            "THEMED_EXCERPT_CONTENT_EXACT_FIELD_SUFFIX": "_exact",
+            "THEMED_EXCERPT_PUBLICATION_DATE_FIELD": "publication_date",
+            "THEMED_EXCERPT_SCRAPED_AT_FIELD": "scraped_at",
+            "THEMED_EXCERPT_TERRITORY_ID_FIELD": "territory_id",
+            "THEMED_EXCERPT_ENTITIES_FIELD": "entities",
+            "THEMED_EXCERPT_SUBTHEMES_FIELD": "subthemes",
+            "THEMED_EXCERPT_EMBEDDING_SCORE_FIELD": "embedding_score",
+            "THEMED_EXCERPT_TFIDF_SCORE_FIELD": "tfidf_score",
+            "THEMED_EXCERPT_FRAGMENT_SIZE": 1000,
+            "THEMED_EXCERPT_NUMBER_OF_FRAGMENTS": 3,
+            "POSTGRES_COMPANIES_HOST": "localhost",
+            "POSTGRES_COMPANIES_DB": "companies_test",
+            "POSTGRES_COMPANIES_USER": "test_user",
+            "POSTGRES_COMPANIES_PASSWORD": "test_password",
+            "POSTGRES_COMPANIES_PORT": "5432",
+            "QUERIDO_DIARIO_OPENSEARCH_USER": "admin",
+            "QUERIDO_DIARIO_OPENSEARCH_PASSWORD": "admin_password",
+            "POSTGRES_AGGREGATES_HOST": "localhost",
+            "POSTGRES_AGGREGATES_DB": "aggregates_test",
+            "POSTGRES_AGGREGATES_USER": "test_user",
+            "POSTGRES_AGGREGATES_PASSWORD": "test_password",
+            "POSTGRES_AGGREGATES_PORT": "5432",
         }
         configuration = load_configuration()
         self.check_configuration_values(configuration, expected_config_dict)

--- a/tests/test_csv_database.py
+++ b/tests/test_csv_database.py
@@ -5,8 +5,8 @@ import unittest
 from tempfile import NamedTemporaryFile
 import csv
 
-from gazettes import GazetteDataGateway, Gazette, OpennessLevel, City
-from database.csv import CSVDatabase
+from cities import create_cities_data_gateway
+from cities.city_access import CitySearchResult, OpennessLevel
 
 
 class CSVDatabaseTests(TestCase):
@@ -39,99 +39,231 @@ class CSVDatabaseTests(TestCase):
                     "https://anotherwebsite.org",
                 ],
             },
+            {
+                "city_name": "São Paulo de Olivença",
+                "ibge_id": "1237",
+                "uf": "AM",
+                "openness_level": 0,
+                "gazettes_urls":[]
+            },
+            {
+                "city_name": "São Paulo do Potengi",
+                "ibge_id": "1238",
+                "uf": "RN",
+                "openness_level": 0,
+                "gazettes_urls": []
+            },
+            {
+                "city_name": "São Paulo",
+                "ibge_id": "1239",
+                "uf": "SP",
+                "openness_level": 1,
+                "gazettes_urls": [
+                    "https://somewebsite.org"
+                ]
+            },
         ]
         self.database_file = NamedTemporaryFile(delete=False).name
         self.create_fake_csv_database_file(self.fake_database_data)
 
+
     def tearDown(self):
         if self.database_file is not None:
             os.remove(self.database_file)
+
 
     def create_fake_csv_database_file(self, data):
         with open(self.database_file, "w", newline="") as csvfile:
             fieldnames = list(data[0].keys())
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
+
             for row in data:
                 row["gazettes_urls"] = ",".join(row["gazettes_urls"])
                 writer.writerow(row)
 
+
+    def create_database(self):
+        city_database_file = os.environ.get('CITY_DATABASE_CSV')
+        database = create_cities_data_gateway(city_database_file)
+        return database
+
+
     def test_get_file_name_from_envvar(self):
         with patch.dict(
-            os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": self.database_file}
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
         ):
-            database = CSVDatabase()
-            self.assertEqual(self.database_file, database.database_file)
+            database = self.create_database()
+            self.assertEqual(self.database_file, database._database_file)
+
 
     @expectedFailure
     def test_create_csv_database_without_envvar_with_file_path(self):
-        with patch.dict(
-            os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": "/path/does/not/exists"}
-        ):
-            database = CSVDatabase()
-        with patch.dict(os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": ""}):
-            database = CSVDatabase()
+        with patch.dict(os.environ, {"CITY_DATABASE_CSV": "/path/does/not/exists"}):
+            database = self.create_database()
+
+        with patch.dict(os.environ, {"CITY_DATABASE_CSV": ""}):
+            database = self.create_database()
+
         with patch.dict(os.environ, {}):
-            database = CSVDatabase()
+            database = self.create_database()
+
 
     def test_get_one_city_by_name(self):
         with patch.dict(
-            os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": self.database_file}
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
         ):
-            database = CSVDatabase()
-            city = database.get_cities("pira")
-            expected_city = City(
-                "Piraporinha",
-                "1234",
-                "SC",
-                OpennessLevel("2"),
-                ["https://somewebsite.org"],
+            database = self.create_database()
+
+            city = database.get_cities("pira", [])
+
+            expected_cites = CitySearchResult(
+                name="Piraporinha",
+                ibge_id="1234",
+                uf="SC",
+                openness_level=OpennessLevel.TWO,
+                gazettes_urls=['https://somewebsite.org']
             )
+
+            self.assertCountEqual([expected_cites], city)
+
+
+    def test_get_one_city_by_name_and_by_level(self):
+            with patch.dict(
+                os.environ, {"CITY_DATABASE_CSV": self.database_file}
+            ):
+                database = self.create_database()
+
+                levels = ["2"]
+
+                city = database.get_cities("pira", levels)
+
+                expected_cites = CitySearchResult(
+                    name="Piraporinha",
+                    ibge_id="1234",
+                    uf="SC",
+                    openness_level=OpennessLevel.TWO,
+                    gazettes_urls=['https://somewebsite.org']
+                )
+
+                self.assertCountEqual([expected_cites], city)
+
+
+    def test_get_one_city_by_name_by_multiple_levels(self):
+        with patch.dict(
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
+        ):
+            database = self.create_database()
+
+            levels = ["0","1","2"]
+            city = database.get_cities("pira", [])
+
+            expected_city = CitySearchResult(
+                name="Piraporinha",
+                ibge_id="1234",
+                uf="SC",
+                openness_level=OpennessLevel.TWO,
+                gazettes_urls=['https://somewebsite.org']
+            )
+
             self.assertCountEqual([expected_city], city)
+
 
     def test_get_multiple_cities(self):
         with patch.dict(
-            os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": self.database_file}
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
         ):
-            database = CSVDatabase()
-            cities = database.get_cities("taquarinha")
+            database = self.create_database()
+
+            levels = []
+            cities = database.get_cities("taquarinha",levels)
+
             expected_cities = [
-                City(
+                CitySearchResult(
                     "Taquarinha Do Norte",
                     "1235",
                     "RN",
-                    OpennessLevel("1"),
+                    OpennessLevel.ONE,
                     ["https://somewebsite.org", "https://anotherwebsite.org"],
                 ),
-                City(
+
+                CitySearchResult(
                     "Taquarinha Do Sul",
                     "1236",
                     "RS",
-                    OpennessLevel("3"),
+                    OpennessLevel.THREE,
                     ["https://somewebsite.org", "https://anotherwebsite.org"],
                 ),
             ]
+
             self.assertCountEqual(expected_cities, cities)
 
-    def test_get_one_city_by_territory_id(self):
+
+    def test_get_one_city_by_invalid_level(self):
         with patch.dict(
-            os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": self.database_file}
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
         ):
-            database = CSVDatabase()
-            city = database.get_city("1234")
-            expected_city = City(
+            database = self.create_database()
+
+            levels = ["2"]
+            cities = database.get_cities("São Paulo",levels)
+
+            expected_cities = []
+
+            self.assertCountEqual(expected_cities, cities)
+
+
+    def test_get_multiple_cities_with_unique_level(self):
+        with patch.dict(
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
+        ):
+            database = self.create_database()
+
+            levels = ["0"]
+            cities = database.get_cities("São Paulo",levels)
+
+            expected_cities = [
+                CitySearchResult(
+                    "São Paulo de Olivença",
+                    "1237",
+                    "AM",
+                    OpennessLevel.ZERO,
+                    None,
+                ),
+
+                CitySearchResult(
+                    "São Paulo do Potengi",
+                    "1238",
+                    "RN",
+                    OpennessLevel.ZERO,
+                    None,
+                ),
+            ]
+
+            self.assertCountEqual(expected_cities, cities)
+
+
+    def test_get_one_city_by_ibge_id(self):
+        with patch.dict(
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
+        ):
+            expected_city = CitySearchResult(
                 "Piraporinha",
                 "1234",
                 "SC",
-                OpennessLevel("2"),
+                OpennessLevel.TWO,
                 ["https://somewebsite.org"],
             )
+
+            database = self.create_database()
+            city = database.get_city("1234")
             self.assertEqual(expected_city, city)
 
-    def test_get_none_by_invalid_territory_id(self):
+
+    def test_get_none_by_invalid_ibge_id(self):
         with patch.dict(
-            os.environ, {"QUERIDO_DIARIO_DATABASE_CSV": self.database_file}
+            os.environ, {"CITY_DATABASE_CSV": self.database_file}
         ):
-            database = CSVDatabase()
+            database = self.create_database()
             city = database.get_city("invalid_id")
             self.assertEqual(None, city)


### PR DESCRIPTION
Refatorei os testes e os coloquei para funcionar novamente. Não adicionei muitos testes, pois foquei em corrigir e fazer os testes existentes funcionarem novamente.

## Algumas coisas que fiz

### 1. Criei mocks extras para `aggregates`, `themed_excerpts` e `cities`.  

Criei esses mocks porque `configure_api_app` requeria três argumentos que estavam faltando. 

### 2. Criei o método `create_mock_city_interface`.

Criei esse método para separar os métodos `get_cities` e `get_city`, permitindo que fossem usados no `MockCityAccessInterface`.

### 3. Criei o método `get_test_client(self, **kwargs)` que retorna uma instância de `TestClient`.

Este método cria e retorna uma instância de `TestClient` configurada com mocks personalizados para testar a aplicação.

O método aceita argumentos extras (`kwargs`), onde cada chave corresponde ao nome de um componente (como `gazettes`) e o valor é o mock personalizado para substituir o padrão. Isso permite passar mocks personalizados sem a necessidade de reescrever o `configure_api_app`.

### Exemplo:
```python
interface = self.create_mock_gazette_interface(
            (
                1,
                [
                    {
                        "territory_id": "4205902",
                        "date": today,
                        "scraped_at": formatted_datetime_now,
                        "url": "https://queridodiario.ok.org.br/",
                        "territory_name": "My city",
                        "state_code": "My state",
                        "excerpts": [],
                        "is_extra_edition": False,
                        "edition": "12.3442",
                        "txt_url": "https://queridodiario.ok.org.br/",
                    }
                ],
            )
        )

client = self.get_test_client(gazettes=interface)
```
### 4. criei alguns testes para `scraped_since` e `scraped_until`