### PR TITLE
fix: aplica transformação de URL no campo 'url' principal

### DIFF
--- a/gazettes/gazette_access.py
+++ b/gazettes/gazette_access.py
@@ -411,6 +411,9 @@ class GazetteSearchEngineGateway(GazetteDataGateway):
         )
 
         # Build file URL from relative path or process legacy URL
+        file_url = gazette["_source"]["url"]
+        url = self._build_file_url(file_url)
+
         file_raw_txt = gazette["_source"].get("file_raw_txt", None)
         txt_url = self._build_file_url(file_raw_txt) if file_raw_txt else None
 
@@ -418,7 +421,7 @@ class GazetteSearchEngineGateway(GazetteDataGateway):
             gazette["_source"]["territory_id"],
             datetime.strptime(gazette["_source"]["date"], "%Y-%m-%d").date(),
             datetime.fromisoformat(gazette["_source"]["scraped_at"]),
-            gazette["_source"]["url"],
+            url,
             gazette["_source"]["file_checksum"],
             gazette["_source"]["territory_name"],
             gazette["_source"]["state_code"],

--- a/tests/test_gazette_file_url_builder.py
+++ b/tests/test_gazette_file_url_builder.py
@@ -1,0 +1,245 @@
+import os
+import unittest
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+from gazettes.gazette_access import GazetteSearchEngineGateway
+from index import SearchEngineInterface
+
+
+class TestGazetteFileUrlBuilder(unittest.TestCase):
+    """
+    Tests for the _build_file_url method in GazetteSearchEngineGateway
+    to ensure URL transformation works correctly with the REPLACE_FILE_URL_BASE
+    feature flag.
+    """
+
+    def setUp(self):
+        """Set up a mock gateway for testing"""
+        self.mock_engine = MagicMock(spec=SearchEngineInterface)
+        self.mock_engine.index_exists.return_value = True
+        self.mock_query_builder = MagicMock()
+
+        self.gateway = GazetteSearchEngineGateway(
+            search_engine=self.mock_engine,
+            query_builder=self.mock_query_builder,
+            index="test_index",
+        )
+
+    def test_relative_path_without_endpoint(self):
+        """Test relative path without QUERIDO_DIARIO_FILES_ENDPOINT returns as-is"""
+        with patch.dict(os.environ, {}, clear=True):
+            result = self.gateway._build_file_url("3304557/2019/file.pdf")
+            self.assertEqual(result, "3304557/2019/file.pdf")
+
+    def test_relative_path_with_endpoint(self):
+        """Test relative path with QUERIDO_DIARIO_FILES_ENDPOINT builds full URL"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            result = self.gateway._build_file_url("3304557/2019/file.pdf")
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_relative_path_with_endpoint_trailing_slash(self):
+        """Test relative path handles trailing slash correctly"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br/"},
+        ):
+            result = self.gateway._build_file_url("3304557/2019/file.pdf")
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_relative_path_with_leading_slash(self):
+        """Test relative path with leading slash is handled correctly"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            result = self.gateway._build_file_url("/3304557/2019/file.pdf")
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_full_url_without_replace_flag(self):
+        """Test full URL without REPLACE_FILE_URL_BASE returns as-is (legacy mode)"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            original_url = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(result, original_url)
+
+    def test_full_url_with_replace_flag_false(self):
+        """Test full URL with REPLACE_FILE_URL_BASE=false returns as-is"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "false",
+            },
+        ):
+            original_url = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(result, original_url)
+
+    def test_full_url_with_replace_flag_true_https(self):
+        """Test full URL with REPLACE_FILE_URL_BASE=true replaces base URL (https)"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            original_url = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_full_url_with_replace_flag_true_http(self):
+        """Test full URL with REPLACE_FILE_URL_BASE=true replaces base URL (http)"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            original_url = "http://oldserver.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_full_url_with_replace_flag_true_s3(self):
+        """Test full URL with REPLACE_FILE_URL_BASE=true replaces base URL (s3)"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            original_url = "s3://my-bucket/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_replace_flag_case_insensitive(self):
+        """Test REPLACE_FILE_URL_BASE is case insensitive"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "TrUe",
+            },
+        ):
+            original_url = "https://oldserver.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_assemble_gazette_object_applies_url_transformation(self):
+        """Test that _assemble_gazette_object applies URL transformation to url field"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            gazette_hit = {
+                "_source": {
+                    "territory_id": "3304557",
+                    "date": "2019-01-01",
+                    "scraped_at": "2019-01-02T00:00:00",
+                    "url": "https://oldserver.com/3304557/2019/file.pdf",
+                    "file_checksum": "abc123",
+                    "territory_name": "Rio de Janeiro",
+                    "state_code": "RJ",
+                    "file_raw_txt": "https://oldserver.com/3304557/2019/file.txt",
+                }
+            }
+
+            result = self.gateway._assemble_gazette_object(gazette_hit)
+
+            # Verify both url and txt_url are transformed
+            self.assertEqual(
+                result.url, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+            self.assertEqual(
+                result.txt_url,
+                "https://cdn.queridodiario.ok.org.br/3304557/2019/file.txt",
+            )
+
+    def test_assemble_gazette_object_without_txt_url(self):
+        """Test that _assemble_gazette_object handles missing file_raw_txt"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            gazette_hit = {
+                "_source": {
+                    "territory_id": "3304557",
+                    "date": "2019-01-01",
+                    "scraped_at": "2019-01-02T00:00:00",
+                    "url": "https://oldserver.com/3304557/2019/file.pdf",
+                    "file_checksum": "abc123",
+                    "territory_name": "Rio de Janeiro",
+                    "state_code": "RJ",
+                }
+            }
+
+            result = self.gateway._assemble_gazette_object(gazette_hit)
+
+            # Verify url is transformed but txt_url is None
+            self.assertEqual(
+                result.url, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+            self.assertIsNone(result.txt_url)
+
+    def test_assemble_gazette_object_with_relative_paths(self):
+        """Test that _assemble_gazette_object works with relative paths (new data)"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            gazette_hit = {
+                "_source": {
+                    "territory_id": "3304557",
+                    "date": "2019-01-01",
+                    "scraped_at": "2019-01-02T00:00:00",
+                    "url": "3304557/2019/file.pdf",
+                    "file_checksum": "abc123",
+                    "territory_name": "Rio de Janeiro",
+                    "state_code": "RJ",
+                    "file_raw_txt": "3304557/2019/file.txt",
+                }
+            }
+
+            result = self.gateway._assemble_gazette_object(gazette_hit)
+
+            # Verify both are built with endpoint
+            self.assertEqual(
+                result.url, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+            self.assertEqual(
+                result.txt_url,
+                "https://cdn.queridodiario.ok.org.br/3304557/2019/file.txt",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_themed_excerpt_file_url_builder.py
+++ b/tests/test_themed_excerpt_file_url_builder.py
@@ -1,0 +1,212 @@
+import os
+import unittest
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+from themed_excerpts.themed_excerpt_access import ThemedExcerptSearchEngineGateway
+from index import SearchEngineInterface
+
+
+class TestThemedExcerptFileUrlBuilder(unittest.TestCase):
+    """
+    Tests for the _build_file_url method in ThemedExcerptSearchEngineGateway
+    to ensure URL transformation works correctly with the REPLACE_FILE_URL_BASE
+    feature flag.
+    """
+
+    def setUp(self):
+        """Set up a mock gateway for testing"""
+        self.mock_engine = MagicMock(spec=SearchEngineInterface)
+        self.mock_engine.index_exists.return_value = True
+        self.mock_query_builder = MagicMock()
+
+        self.gateway = ThemedExcerptSearchEngineGateway(
+            search_engine=self.mock_engine,
+            query_builder=self.mock_query_builder,
+        )
+
+    def test_relative_path_without_endpoint(self):
+        """Test relative path without QUERIDO_DIARIO_FILES_ENDPOINT returns as-is"""
+        with patch.dict(os.environ, {}, clear=True):
+            result = self.gateway._build_file_url("3304557/2019/file.pdf")
+            self.assertEqual(result, "3304557/2019/file.pdf")
+
+    def test_relative_path_with_endpoint(self):
+        """Test relative path with QUERIDO_DIARIO_FILES_ENDPOINT builds full URL"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            result = self.gateway._build_file_url("3304557/2019/file.pdf")
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_full_url_without_replace_flag(self):
+        """Test full URL without REPLACE_FILE_URL_BASE returns as-is (legacy mode)"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            original_url = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(result, original_url)
+
+    def test_full_url_with_replace_flag_true(self):
+        """Test full URL with REPLACE_FILE_URL_BASE=true replaces base URL"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            original_url = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
+            result = self.gateway._build_file_url(original_url)
+            self.assertEqual(
+                result, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+
+    def test_assemble_themed_excerpt_object_applies_url_transformation(self):
+        """Test that _assemble_themed_excerpt_object applies URL transformation to source_url field"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            excerpt_hit = {
+                "_source": {
+                    "excerpt_id": "excerpt123",
+                    "source_territory_id": "3304557",
+                    "source_date": "2019-01-01",
+                    "source_scraped_at": "2019-01-02T00:00:00",
+                    "source_url": "https://oldserver.com/3304557/2019/file.pdf",
+                    "source_territory_name": "Rio de Janeiro",
+                    "source_state_code": "RJ",
+                    "excerpt_subthemes": ["subtheme1"],
+                    "excerpt": "Test excerpt content",
+                    "source_file_raw_txt": "https://oldserver.com/3304557/2019/file.txt",
+                    "excerpt_entities": [],
+                }
+            }
+
+            result = self.gateway._assemble_themed_excerpt_object(
+                excerpt_hit, "test_theme"
+            )
+
+            # Verify both url and txt_url are transformed
+            self.assertEqual(
+                result.url, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+            self.assertEqual(
+                result.txt_url,
+                "https://cdn.queridodiario.ok.org.br/3304557/2019/file.txt",
+            )
+
+    def test_assemble_themed_excerpt_object_without_txt_url(self):
+        """Test that _assemble_themed_excerpt_object handles missing source_file_raw_txt"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "true",
+            },
+        ):
+            excerpt_hit = {
+                "_source": {
+                    "excerpt_id": "excerpt123",
+                    "source_territory_id": "3304557",
+                    "source_date": "2019-01-01",
+                    "source_scraped_at": "2019-01-02T00:00:00",
+                    "source_url": "https://oldserver.com/3304557/2019/file.pdf",
+                    "source_territory_name": "Rio de Janeiro",
+                    "source_state_code": "RJ",
+                    "excerpt_subthemes": ["subtheme1"],
+                    "excerpt": "Test excerpt content",
+                }
+            }
+
+            result = self.gateway._assemble_themed_excerpt_object(
+                excerpt_hit, "test_theme"
+            )
+
+            # Verify url is transformed but txt_url is None
+            self.assertEqual(
+                result.url, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+            self.assertIsNone(result.txt_url)
+
+    def test_assemble_themed_excerpt_object_with_relative_paths(self):
+        """Test that _assemble_themed_excerpt_object works with relative paths (new data)"""
+        with patch.dict(
+            os.environ,
+            {"QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br"},
+        ):
+            excerpt_hit = {
+                "_source": {
+                    "excerpt_id": "excerpt123",
+                    "source_territory_id": "3304557",
+                    "source_date": "2019-01-01",
+                    "source_scraped_at": "2019-01-02T00:00:00",
+                    "source_url": "3304557/2019/file.pdf",
+                    "source_territory_name": "Rio de Janeiro",
+                    "source_state_code": "RJ",
+                    "excerpt_subthemes": ["subtheme1"],
+                    "excerpt": "Test excerpt content",
+                    "source_file_raw_txt": "3304557/2019/file.txt",
+                }
+            }
+
+            result = self.gateway._assemble_themed_excerpt_object(
+                excerpt_hit, "test_theme"
+            )
+
+            # Verify both are built with endpoint
+            self.assertEqual(
+                result.url, "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
+            )
+            self.assertEqual(
+                result.txt_url,
+                "https://cdn.queridodiario.ok.org.br/3304557/2019/file.txt",
+            )
+
+    def test_assemble_themed_excerpt_object_legacy_mode(self):
+        """Test that _assemble_themed_excerpt_object preserves URLs in legacy mode"""
+        with patch.dict(
+            os.environ,
+            {
+                "QUERIDO_DIARIO_FILES_ENDPOINT": "https://cdn.queridodiario.ok.org.br",
+                "REPLACE_FILE_URL_BASE": "false",
+            },
+        ):
+            original_url = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
+            original_txt = "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.txt"
+
+            excerpt_hit = {
+                "_source": {
+                    "excerpt_id": "excerpt123",
+                    "source_territory_id": "3304557",
+                    "source_date": "2019-01-01",
+                    "source_scraped_at": "2019-01-02T00:00:00",
+                    "source_url": original_url,
+                    "source_territory_name": "Rio de Janeiro",
+                    "source_state_code": "RJ",
+                    "excerpt_subthemes": ["subtheme1"],
+                    "excerpt": "Test excerpt content",
+                    "source_file_raw_txt": original_txt,
+                }
+            }
+
+            result = self.gateway._assemble_themed_excerpt_object(
+                excerpt_hit, "test_theme"
+            )
+
+            # Verify URLs are preserved as-is
+            self.assertEqual(result.url, original_url)
+            self.assertEqual(result.txt_url, original_txt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/themed_excerpts/themed_excerpt_access.py
+++ b/themed_excerpts/themed_excerpt_access.py
@@ -518,6 +518,9 @@ class ThemedExcerptSearchEngineGateway(ThemedExcerptDataGateway):
         )
 
         # Build file URL from relative path or process legacy URL
+        file_url = excerpt["_source"]["source_url"]
+        url = self._build_file_url(file_url)
+
         file_raw_txt = excerpt["_source"].get("source_file_raw_txt", None)
         txt_url = self._build_file_url(file_raw_txt) if file_raw_txt else None
 
@@ -526,7 +529,7 @@ class ThemedExcerptSearchEngineGateway(ThemedExcerptDataGateway):
             excerpt["_source"]["source_territory_id"],
             datetime.strptime(excerpt["_source"]["source_date"], "%Y-%m-%d").date(),
             datetime.fromisoformat(excerpt["_source"]["source_scraped_at"]),
-            excerpt["_source"]["source_url"],
+            url,
             excerpt["_source"]["source_territory_name"],
             excerpt["_source"]["source_state_code"],
             excerpt["_source"]["excerpt_subthemes"],


### PR DESCRIPTION
## 🐛 Problema Identificado

A feature flag `REPLACE_FILE_URL_BASE` não estava funcionando em produção. Os resultados da API ainda retornavam URLs completas com o domínio antigo, mesmo com a flag habilitada.

### Causa Raiz
No commit #86, a função `_build_file_url()` foi implementada mas só estava sendo aplicada ao campo `txt_url`. O campo principal `url` continuava sendo retornado diretamente do banco de dados sem transformação.

## ✅ Correções Implementadas

### Arquivos modificados:
- `gazettes/gazette_access.py`: Aplica `_build_file_url()` ao campo `url`
- `themed_excerpts/themed_excerpt_access.py`: Aplica `_build_file_url()` ao campo `source_url`

### Comportamento após a correção:
Quando configurado com:
```bash
REPLACE_FILE_URL_BASE=true
QUERIDO_DIARIO_FILES_ENDPOINT=https://cdn.queridodiario.ok.org.br
```

**Ambos** os campos `url` e `txt_url` serão transformados:
```
❌ Antes: "url": "https://queridodiario.nyc3.digitaloceanspaces.com/3304557/2019/file.pdf"
✅ Depois: "url": "https://cdn.queridodiario.ok.org.br/3304557/2019/file.pdf"
```

## 🧪 Testes Adicionados

Foram criados **21 novos testes** para evitar regressão:

### `tests/test_gazette_file_url_builder.py` (13 testes)
- ✅ Caminhos relativos (dados novos)
- ✅ URLs completas com substituição de base (migração)
- ✅ URLs completas sem alteração (modo legado)
- ✅ Protocolos diversos (http://, https://, s3://)
- ✅ Edge cases (trailing slashes, case insensitive)
- ✅ Integração com `_assemble_gazette_object`

### `tests/test_themed_excerpt_file_url_builder.py` (8 testes)
- ✅ Mesma cobertura para themed excerpts
- ✅ Garante ambos os campos são transformados

## 🔍 Validação

```bash
Ran 67 tests in 0.317s

OK (expected failures=1)
```

✅ Todos os 46 testes existentes + 21 novos testes passando

## 📝 Checklist

- [x] Código corrigido em ambos os módulos (gazettes e themed_excerpts)
- [x] Testes unitários abrangentes adicionados
- [x] Todos os testes passando
- [x] Backward compatibility mantida (modo legado funciona)
- [x] Documentação inline nos testes

## 🚀 Deploy

Após o merge e deploy, a API retornará URLs com o CDN configurado em `QUERIDO_DIARIO_FILES_ENDPOINT` quando `REPLACE_FILE_URL_BASE=true`.