### PR TITLE
fix: corrige setup de arquivos de ambiente nos workflows de CI

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -53,9 +53,9 @@ jobs:
           docker compose version
       - name: Setup environment files
         run: |
-          cp --no-clobber config/sample.env config/current.env || true
-          test -f censo.csv || curl -s -O https://querido-diario.nyc3.cdn.digitaloceanspaces.com/censo/censo.csv
-          test -f themes_config.json || curl -s -O https://raw.githubusercontent.com/okfn-brasil/querido-diario-data-processing/main/config/themes_config.json
+          cp --update=none config/sample.env config/current.env || true
+          test -f censo.csv || curl -fsSO https://data.queridodiario.ok.org.br/censo/censo.csv
+          test -f themes_config.json || curl -fsSO https://raw.githubusercontent.com/okfn-brasil/querido-diario-data-processing/main/config/themes_config.json
       - name: Monitor disk usage before build
         run: |
           echo "=== Disk usage before build ==="


### PR DESCRIPTION
## Problema

O workflow `build_container_image.yaml` tinha dois problemas no step *Setup environment files*:

1. **`cp --no-clobber`**: No coreutils 9.4+ (Ubuntu 24.04), essa flag foi alterada para sair com código 1 quando o destino já existe, gerando o warning `behavior of -n is non-portable`. A flag recomendada pelo próprio coreutils é `--update=none`.

2. **URL do `censo.csv` desatualizada**: A URL apontava para `querido-diario.nyc3.cdn.digitaloceanspaces.com` (DigitalOcean CDN desativado), causando falha de DNS (curl exit code 6) no runner arm64.

## Solução

- `--no-clobber` → `--update=none`
- URL censo.csv → `https://data.queridodiario.ok.org.br/censo/censo.csv`
- Adicionada flag `-f` no `curl` para falhar explicitamente em erros HTTP (4xx/5xx)

Essas mesmas correções já foram aplicadas ao `test_pull_request.yml` no PR #106.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)